### PR TITLE
feat: add llms.txt for AI crawlers

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,72 @@
+# the-gpl
+
+> Go learning repository: worked examples and exercises from "The Go Programming Language" by Donovan & Kernighan.
+
+Module: github.com/opendroid/the-gpl
+Language: Go 1.25
+License: AGPL-3.0
+Live site: https://the-gpl.com
+Source: https://github.com/opendroid/the-gpl
+
+## Chapters
+
+- [Chapter 1 — Tutorial](https://github.com/opendroid/the-gpl/tree/master/chapter1): Lissajous GIF, HTTP fetch, duplicate line finder, maps/arrays/strings, goroutine channels, Dialogflow bot, Speech-to-Text live caption.
+- [Chapter 2 — Program Structure](https://github.com/opendroid/the-gpl/tree/master/chapter2): Bit counting (popcount), temperature unit conversion (°F/°C/°K).
+- [Chapter 3 — Basic Types](https://github.com/opendroid/the-gpl/tree/master/chapter3): Mandelbrot fractal renderer (color + B&W), 3-D surface plots (sinc/egg/valley/square), string utilities, numeric constants.
+- [Chapter 4 — Composite Types](https://github.com/opendroid/the-gpl/tree/master/chapter4): Arrays, slices, maps, structs, JSON/XML marshalling, GitHub issues API client, git commit templates.
+- [Chapter 5 — Functions](https://github.com/opendroid/the-gpl/tree/master/chapter5): Recursive HTML link finder, HTML pretty-printer, web crawler (Exercise 5.13), topological sort, variadic functions, closures.
+- [Chapter 6 — Methods](https://github.com/opendroid/the-gpl/tree/master/chapter6): IntSet type using a bit-vector, method sets, pointer vs value receivers.
+- [Chapter 7 — Interfaces](https://github.com/opendroid/the-gpl/tree/master/chapter7): Temperature converter interface, http.Handler counter, sort.Interface, cobra CLI wired through interfaces.
+- [Chapter 8 — Goroutines and Channels](https://github.com/opendroid/the-gpl/tree/master/chapter8): Clock/reverb/chat TCP servers and clients, concurrent disk-usage (du), FTP server, parallel web search (Google/Bing).
+
+## Web Routes (https://the-gpl.com)
+
+- [/index](https://the-gpl.com/index) — Home page
+- [/about](https://the-gpl.com/about) — About page
+- [/lis](https://the-gpl.com/lis) — Lissajous animated GIF
+- [/mandel](https://the-gpl.com/mandel) — Mandelbrot fractal (color)
+- [/mandelbw](https://the-gpl.com/mandelbw) — Mandelbrot fractal (B&W)
+- [/sinc](https://the-gpl.com/sinc) — 3-D sinc surface (SVG)
+- [/egg](https://the-gpl.com/egg) — 3-D egg surface (SVG)
+- [/valley](https://the-gpl.com/valley) — 3-D valley surface (SVG)
+- [/sq](https://the-gpl.com/sq) — 3-D square surface (SVG)
+- [/search?q=...&Timeout=3s](https://the-gpl.com/search) — Parallel web search
+- [/who](https://the-gpl.com/who) — Repository info (JSON)
+- [/llms.txt](https://the-gpl.com/llms.txt) — This file
+
+## CLI Commands
+
+```
+the-gpl server --port=8080          # Start HTTP server
+the-gpl lissajous --file=out.gif    # Generate Lissajous GIF
+the-gpl bits --n=0xBAD0FACE         # Count 1-bits in hex number
+the-gpl temp --c=100                # Temperature conversions
+the-gpl mas --fn=array              # Maps/arrays/strings examples
+the-gpl parse --type=links --site=https://example.com  # HTML parsing
+the-gpl du --dir=$HOME              # Concurrent disk usage
+the-gpl service -sp="clock:9999"    # Start TCP clock service
+the-gpl client  -cp="clock:9999"    # Connect TCP clock client
+the-gpl bot --project=gcp-project   # Dialogflow chatbot
+the-gpl stt --port=9999             # Speech-to-text from RTP stream
+```
+
+## Key Packages
+
+- `serve/web` — HTTP handlers, HTML templates, static file serving
+- `chapter1/lissajous` — Lissajous GIF generator
+- `chapter1/bot` — Dialogflow conversational agent
+- `chapter1/livecaption` — Google Speech-to-Text over RTP/UDP
+- `chapter3` — Mandelbrot and 3-D surface renderers
+- `chapter5` — HTML parsing and web crawling utilities
+- `chapter6` — IntSet bit-vector implementation
+- `chapter8/search` — Parallel web search (Google, Bing)
+- `cmd` — Cobra CLI root and subcommands
+
+## Build and Run
+
+```
+go build ./...
+go test ./...
+the-gpl server --port=8080
+docker build -t the-gpl . && docker run -p 8080:8080 the-gpl
+```

--- a/serve/web/pagedata.go
+++ b/serve/web/pagedata.go
@@ -55,6 +55,7 @@ const (
 	sqSVGImagePath     string    = "/sqSVG.svg"
 	sincSVGImagePath   string    = "/sincSVG.svg"
 	eggSVGImagePath    string    = "/eggSVG.svg"
+	llmsTxt            string    = "/llms.txt"
 	robotsTxt          string    = "/robots.txt"
 	sitemapXML         string    = "/sitemap.xml"
 	favicon16          string    = "/public/images/icons/favicon-16x16.png"

--- a/serve/web/web.go
+++ b/serve/web/web.go
@@ -59,7 +59,8 @@ func init() {
 	handlers[eggSVGImagePath] = gzipSVG(chapter3.EggHandlerSVG)
 	handlers[sqSVGImagePath] = gzipSVG(chapter3.SquaresHandlerSVG)
 
-	// SEO related
+	// SEO and AI crawler related
+	handlers[llmsTxt] = fileHandler("llms.txt")
 	handlers[robotsTxt] = fileHandler("public/robots.txt")
 	handlers[sitemapXML] = fileHandler("public/sitemap.xml")
 	handlers[favicon] = fileHandler("public/images/icons/favicon-16x16.png")


### PR DESCRIPTION
## Summary

- Adds `/workspace/the-gpl/llms.txt` at repo root following the [llmstxt.org](https://llmstxt.org/) spec
- Registers `GET /llms.txt` handler in `serve/web/web.go` so it is served at `the-gpl.com/llms.txt`
- File lists all chapters, web routes, and CLI commands in a structured plain-text format readable by LLM crawlers

## Test plan

- [ ] `curl http://localhost:8080/llms.txt` returns the file with correct content
- [ ] `go build ./...` passes
- [ ] `go test ./serve/web/...` passes

Closes #3

---
_Generated by [Claude Code](https://claude.ai/code/session_012g3edjKRKYuy1PBNLfov96)_