### PR TITLE
feat: add README.md for chapters 1–3, 5–8

### DIFF
--- a/chapter1/README.md
+++ b/chapter1/README.md
@@ -1,0 +1,115 @@
+# Chapter 1 — A Tutorial
+
+Miscellaneous introductory examples from Chapter 1 of *The Go Programming Language*,
+extended with Google Cloud integrations (Dialogflow, Speech-to-Text).
+
+## Sub-packages
+
+| Package | CLI command | What it covers |
+|---|---|---|
+| `lissajous/` | `the-gpl lissajous` | Animated GIF generation; web handler |
+| `channels/` | `the-gpl fetch` | Concurrent HTTP fetch using goroutines + channels |
+| `mas/` | `the-gpl mas` | Maps, arrays, and string utilities |
+| `bot/` | `the-gpl bot` | Dialogflow conversational agent |
+| `livecaption/` | `the-gpl stt` | Google Speech-to-Text from a live RTP stream |
+| `dup/` | — | Duplicate-line counter (stdin) |
+| `structs/` | — | Pointer vs value receiver demonstration |
+
+## Key Concepts
+
+### Goroutines and Channels (`channels/`)
+
+```go
+ch := make(chan string)
+go channels.FetchTimeInfo("https://example.com", ch)
+fmt.Println(<-ch)
+```
+
+- `Fetch(url string) (string, error)` — fetches a URL body.
+- `FetchTimeInfo(url string, ch chan<- string)` — times a fetch and sends result on a channel.
+- `GithubReposOfUser(username string, responses chan<- GithubUserInfo)` — fetches GitHub repos concurrently.
+
+### Lissajous GIF (`lissajous/`)
+
+```go
+lissajous.Lissajous(os.Stdout, lissajous.Config{Cycles: 5, Size: 256, Frames: 64, Delay: 8})
+```
+
+- `Figure(w http.ResponseWriter, r *http.Request)` — HTTP handler; powers `https://the-gpl.com/lis`.
+- `Default(w io.Writer)` — writes a GIF with default parameters.
+
+### Maps, Arrays, Strings (`mas/`)
+
+```go
+mas.IterateOverArray()
+n1, _ := mas.CompareNumbers(42, 99)
+mas.AddToSlices()
+```
+
+CLI: `the-gpl mas --fn=array|comp|slice`
+
+### Structs and Receivers (`structs/`)
+
+Demonstrates the difference between pointer receivers (mutations persist) and value receivers (mutations are local copies):
+
+```go
+t := structs.NewThakur("Alice", 30)
+t.ChangeToHeadOfHousehold() // pointer receiver — t is modified
+```
+
+### Dialogflow Bot (`bot/`)
+
+Connects to a GCP Dialogflow agent and holds a short conversation.
+
+```bash
+the-gpl bot --project=my-gcp-project-id
+the-gpl bot --project=my-gcp-project-id --chat=true   # stdin chat mode
+```
+
+Requires `GOOGLE_APPLICATION_CREDENTIALS` pointing to a service-account JSON file.
+
+### Speech-to-Text (`livecaption/`)
+
+Streams audio from an RTP/UDP port to the Google Cloud Speech-to-Text API and prints live transcripts.
+
+```bash
+# macOS: stream microphone over RTP
+ffmpeg -f avfoundation -i ":1" -acodec pcm_s16le -ar 48000 -f s16le udp://localhost:9999
+# Transcribe
+the-gpl stt --port=9999
+```
+
+- `StreamRTPPort(address string, w io.Writer)` — listens on UDP and streams to STT.
+- `StreamAudioFile(fName string, w io.Writer)` — streams a WAV file for testing.
+
+## Running the Examples
+
+```bash
+# Fetch two URLs concurrently and print times
+the-gpl fetch --site=https://golang.org
+
+# Generate a Lissajous GIF
+the-gpl lissajous --cycles=5 --size=512 --frames=64 --file=~/Downloads/lis.gif
+
+# Maps/arrays/strings demo
+the-gpl mas --fn=array
+the-gpl mas --fn=comp --n1=10 --n2=20
+```
+
+## Tests
+
+```bash
+go test ./chapter1/...
+go test -v ./chapter1/lissajous/...
+```
+
+## Go Features Demonstrated
+
+- Goroutines (`go f()`) and unbuffered/buffered channels
+- `for range` over arrays and slices
+- Anonymous functions and closures
+- Multiple return values and blank identifier `_`
+- `net/http` client and server basics
+- `image/color` and `image/gif` for image generation
+- Interface satisfaction (`io.Writer`, `http.Handler`)
+- Pointer vs value receivers on struct methods

--- a/chapter2/README.md
+++ b/chapter2/README.md
@@ -1,0 +1,82 @@
+# Chapter 2 — Program Structure
+
+Examples from Chapter 2 of *The Go Programming Language*, covering declarations,
+types, scope, constants, and package organisation.
+
+## Sub-packages
+
+| Package | CLI command | What it covers |
+|---|---|---|
+| `bitsCount/` | `the-gpl bits` | Bit-counting algorithms (popcount) |
+| `tempConv/` | `the-gpl temp` | Temperature unit types and conversion methods |
+
+## Bit Counting (`bitsCount/`)
+
+Implements three strategies for counting the number of 1-bits (popcount) in a `uint64`,
+illustrating the trade-off between lookup-table precomputation and per-bit iteration.
+
+```go
+n := uint64(0xBAD0FACE)
+fmt.Println(bitsCount.BitCount(n))              // fastest: 4-byte table lookup
+fmt.Println(bitsCount.BitCountByTableLookup(n)) // 1-byte table lookup (~30× slower)
+fmt.Println(bitsCount.BitCountEachOne(n))        // shift each bit (~2× slower than table)
+```
+
+| Function | Strategy | Relative speed |
+|---|---|---|
+| `BitCount(x uint64) int` | 4-byte precomputed table | Fastest |
+| `BitCountByTableLookup(x uint64) int` | 1-byte table per byte | ~30× slower |
+| `BitCountEachOne(x uint64) int` | Shift and mask each bit | Slowest |
+
+```bash
+the-gpl bits --n=0xBAD0FACE
+the-gpl bits --n=255          # all 8 lower bits set → 8
+```
+
+## Temperature Conversion (`tempConv/`)
+
+Defines named numeric types `Celsius`, `Fahrenheit`, and `Kelvin` with conversion
+methods on each — a classic example of Go's type system preventing silent unit errors.
+
+```go
+c := tempConv.Celsius(100)
+fmt.Println(c.ToF())  // 212 °F
+fmt.Println(c.ToK())  // 373.15 K
+fmt.Println(c)        // "100.00°C"  (String() method)
+
+f := tempConv.Fahrenheit(32)
+fmt.Println(f.ToC())  // 0 °C
+```
+
+### Types
+
+| Type | Underlying | Methods |
+|---|---|---|
+| `Celsius` | `float64` | `ToF()`, `ToK()`, `String()` |
+| `Fahrenheit` | `float64` | `ToC()`, `ToK()`, `String()` |
+| `Kelvin` | `float64` | `ToF()`, `ToC()`, `String()` |
+
+```bash
+the-gpl temp --c=100         # convert 100 °C
+the-gpl temp --f=212         # convert 212 °F
+the-gpl temp --k=373.15      # convert 373.15 K
+```
+
+Also exposed via `chapter7` as a `flag.Value` interface (`CelsiusFlag`, `FahrenheitFlag`, `KelvinFlag`).
+
+## Running Tests
+
+```bash
+go test ./chapter2/...
+go test -v -bench=. ./chapter2/bitsCount/...   # benchmark the three strategies
+```
+
+## Go Features Demonstrated
+
+- Named type declarations (`type Celsius float64`)
+- Methods on non-struct types
+- `String() string` method satisfying `fmt.Stringer`
+- Package-level `init()` for lookup-table precomputation
+- Constant expressions and `iota`
+- Multiple return values
+- Benchmark tests (`testing.B`)

--- a/chapter3/README.md
+++ b/chapter3/README.md
@@ -1,0 +1,105 @@
+# Chapter 3 — Basic Data Types
+
+Examples from Chapter 3 of *The Go Programming Language*, covering integers, floats,
+complex numbers, strings, and constants — made visual through fractal and surface renderers.
+
+## What's Here
+
+| File / Package | Web route | What it does |
+|---|---|---|
+| `mandelbrot.go` | `/mandel`, `/mandelbw` | Mandelbrot fractal PNG (color and B&W) |
+| `surface.go` | `/sinc`, `/egg`, `/valley`, `/sq` | 3-D wire-mesh surface plots as SVG |
+| `tstrings/` | — | String utility functions |
+
+## Mandelbrot Fractal
+
+Renders the Mandelbrot set as a PNG image by iterating `z = z² + c` for each pixel
+and mapping the iteration count to a colour (or black/white threshold).
+
+```go
+// HTTP handlers — registered in serve/web/web.go
+chapter3.MBGraphHandler(w, r)   // colour PNG at /mandelimage.png
+chapter3.MBGraphBWHandler(w, r) // B&W PNG at /mandelbwimage.png
+```
+
+- `SetColor(z complex128, i, maxIter int) color.RGBA` — maps iteration depth to an RGB colour.
+- `MandelbrotImage` type: `MBColor` or `MBBW` enum selects the rendering mode.
+
+View live: [the-gpl.com/mandel](https://the-gpl.com/mandel) · [the-gpl.com/mandelbw](https://the-gpl.com/mandelbw)
+
+## 3-D Surface Plots
+
+Plots `z = f(x, y)` as a wire-mesh SVG using an isometric projection.
+Each surface function is a `func(float64, float64) float64` passed to `PlotOn3DSurface`.
+
+```go
+// Write a sinc SVG to stdout
+chapter3.SincSVG(os.Stdout)
+
+// Plot any custom function
+chapter3.PlotOn3DSurface(os.Stdout, func(x, y float64) float64 {
+    return math.Sin(x) * math.Cos(y)
+})
+```
+
+| Function | Surface shape | Route |
+|---|---|---|
+| `Sinc(x, y float64) float64` | sin(r)/r ripple | `/sinc` |
+| `Egg(x, y float64) float64` | egg-carton bumps | `/egg` |
+| `Valley(x, y float64) float64` | valley / saddle | `/valley` |
+| `Squares(x, y float64) float64` | square-wave grid | `/sq` |
+
+SVG handlers (used by the web server):
+`EggHandlerSVG`, `SincSVG`, `ValleyHandlerSVG`, `SquaresHandlerSVG` — each takes an `io.Writer`.
+
+View live: [/sinc](https://the-gpl.com/sinc) · [/egg](https://the-gpl.com/egg) · [/valley](https://the-gpl.com/valley) · [/sq](https://the-gpl.com/sq)
+
+## String Utilities (`tstrings/`)
+
+```go
+tstrings.Basename("a/b/c.go")         // "c"
+tstrings.Comma("1234567")             // "1,234,567"
+tstrings.CommaWithBuf("9876543")      // "9,876,543"  (bytes.Buffer version)
+tstrings.IntsToString([]int{1, 2, 3}) // "[1, 2, 3]"
+```
+
+Also defines two interfaces:
+
+```go
+type DayOfWeekName interface {
+    DayName(d time.Weekday) string
+    Weekend(d time.Weekday) bool
+    Weekday(d time.Weekday) bool
+}
+
+type MonthOfYearName interface {
+    MonthName(m time.Month) string
+}
+```
+
+## Running Tests
+
+```bash
+go test ./chapter3/...
+go test -v ./chapter3/tstrings/...
+```
+
+## Viewing Locally
+
+```bash
+the-gpl server --port=8080
+# Then open:
+# http://localhost:8080/mandel
+# http://localhost:8080/sinc
+```
+
+## Go Features Demonstrated
+
+- `complex128` arithmetic for fractal iteration
+- `image`, `image/color`, `image/png` standard library
+- `math` functions (`Sin`, `Cos`, `Sqrt`, `Abs`, `IsInf`)
+- SVG generation via `fmt.Fprintf` to `io.Writer`
+- Named constants and `iota`
+- `bytes.Buffer` vs string concatenation for performance
+- Interface definitions with multiple methods
+- `strings` and `strconv` standard library utilities

--- a/chapter5/README.md
+++ b/chapter5/README.md
@@ -1,0 +1,96 @@
+# Chapter 5 — Functions
+
+Examples from Chapter 5 of *The Go Programming Language*, covering first-class functions,
+recursion, multiple return values, variadic functions, closures, and error handling.
+
+## CLI
+
+```bash
+the-gpl parse --type=<type> --site=<url>
+```
+
+| `--type` value | Function called | What it does |
+|---|---|---|
+| `outline` | `ParseOutline` | Prints an outline of HTML tag structure |
+| `links` | `ParseLinks` | Lists all unique `href` links |
+| `images` | `ParseImages` | Lists all unique `<img src>` URLs |
+| `css` | `ParseCss` | Lists all unique CSS `<link>` URLs |
+| `scripts` | `ParseScripts` | Lists all unique `<script src>` URLs |
+| `text` | `ParseText` | Prints text nodes (excluding script/style) |
+| `pretty` | `PrettyHTML` | Pretty-prints indented HTML |
+| `crawl` | `Crawl` | Downloads all pages in domain to `--dir` |
+
+## Key Functions
+
+### HTML Traversal (Exercise 5.1)
+
+```go
+// E51FindLinks recursively collects href values from an HTML parse tree.
+links := chapter5.E51FindLinks([]string{}, rootNode)
+```
+
+Uses `golang.org/x/net/html` for parsing. Recursion replaces a loop to demonstrate
+how the same tree walk can be expressed either way.
+
+### Web Crawler (Exercise 5.13)
+
+```go
+count, err := chapter5.Crawl("https://example.com", "/tmp/crawl")
+```
+
+Downloads all pages within the same domain, mirroring the directory structure locally.
+
+### String Expansion (Exercise 5.9)
+
+```go
+// Expand replaces $var in s by calling f("var").
+result := chapter5.Expand("Hello, $name!", func(v string) string {
+    return map[string]string{"name": "Go"}[v]
+})
+// result == "Hello, Go!"
+```
+
+### Topological Sort
+
+```go
+order := chapter5.TopologicalSort(map[string][]string{
+    "algebra":  {"arithmetic"},
+    "calculus": {"algebra"},
+})
+```
+
+Classic DFS-based sort demonstrating closures capturing the `seen` map.
+
+### Variadic Min/Max
+
+```go
+chapter5.MaxInt(3, 1, 4, 1, 5, 9)        // 9
+chapter5.MaxIntOf(3, 1, 4, 1, 5, 9)      // 9  (requires at least one arg)
+chapter5.MinInt(3, 1, 4, 1, 5, 9)        // 1
+chapter5.Join(", ", "a", "b", "c")        // "a, b, c"
+```
+
+### Hyperlinks Sort Interface
+
+```go
+type Hyperlinks []string  // implements sort.Interface, ignores http/https scheme
+```
+
+## Running Tests
+
+```bash
+go test ./chapter5/...
+go test -v -run TestCrawl ./chapter5/...
+```
+
+## Go Features Demonstrated
+
+- Recursive functions on tree-structured data (`html.Node`)
+- First-class functions passed as arguments (`func(float64, float64) float64`)
+- Closures capturing variables from enclosing scope
+- Multiple return values and named results
+- Variadic functions (`...int`)
+- `defer` for cleanup (file close, mutex unlock)
+- Error values and wrapping with `%w`
+- `golang.org/x/net/html` — HTML tokeniser and parse tree
+- `sort.Interface` implementation on a named slice type

--- a/chapter6/README.md
+++ b/chapter6/README.md
@@ -1,0 +1,83 @@
+# Chapter 6 — Methods
+
+Examples from Chapter 6 of *The Go Programming Language*, covering method declarations,
+pointer vs value receivers, and method sets — illustrated through a full `IntSet` implementation.
+
+## `IntSet` — Bit-Vector Set
+
+`IntSet` is a set of non-negative integers backed by a slice of `uint64` words used as a
+bit array. It demonstrates how a non-trivial data structure can be built entirely from
+methods on a struct type.
+
+```go
+s := chapter6.New()
+s.Add(1)
+s.Add(64)
+s.Add(128)
+fmt.Println(s)     // "{1 64 128}"
+fmt.Println(s.Has(64))  // true
+fmt.Println(s.Len())    // 3
+
+s2 := chapter6.NewWithInts(64, 128, 256)
+s.UnionWith(s2)
+fmt.Println(s)     // "{1 64 128 256}"
+```
+
+## API Reference
+
+### Constructors
+
+| Function | Description |
+|---|---|
+| `New() *IntSet` | Empty set |
+| `NewWithInts(x ...uint) *IntSet` | Pre-populated set |
+
+### Methods on `*IntSet`
+
+| Method | Description |
+|---|---|
+| `Has(x uint) bool` | Reports whether x is in the set |
+| `Add(x uint)` | Adds x to the set |
+| `AddInts(x ...uint)` | Adds multiple values |
+| `Remove(x uint)` | Removes x from the set |
+| `RemoveInts(x ...uint)` | Removes multiple values |
+| `Clear()` | Empties the set |
+| `Len() int` | Number of elements |
+| `Copy() *IntSet` | Returns a deep copy |
+| `Elements() []uint` | Sorted slice of all elements |
+| `String() string` | `"{1 2 3}"` representation |
+| `UnionWith(t *IntSet)` | This set ∪ t (in place) |
+| `IntersectWith(t *IntSet)` | This set ∩ t (in place) |
+| `DifferenceWith(t *IntSet)` | This set − t (in place) |
+| `SymmetricDifference(t *IntSet)` | (A∪B) − (A∩B) (in place) |
+
+## How the Bit-Vector Works
+
+Each `uint64` in the backing slice represents 64 consecutive integers.
+Bit `j` of word `i` is set when integer `64*i + j` is in the set.
+
+```
+word 0: bits 0–63
+word 1: bits 64–127
+...
+```
+
+`Add(x)` sets bit `x%64` in word `x/64`, expanding the slice if needed.
+`Has(x)` checks that bit. `String()` iterates all set bits.
+
+## Running Tests
+
+```bash
+go test ./chapter6/...
+go test -v ./chapter6/...   # see each operation tested
+```
+
+## Go Features Demonstrated
+
+- Methods on struct types with pointer receivers (`*IntSet`)
+- Bit manipulation: `|=`, `&=`, `^`, `>>`, `&1`
+- Slice growth with `append`
+- `fmt.Stringer` interface via `String() string`
+- Variadic methods (`AddInts(x ...uint)`)
+- Deep copy semantics
+- Method sets: pointer receiver methods not in value method set

--- a/chapter7/README.md
+++ b/chapter7/README.md
@@ -1,0 +1,105 @@
+# Chapter 7 — Interfaces
+
+Examples from Chapter 7 of *The Go Programming Language*, covering interface types,
+the `io.Writer` interface, `sort.Interface`, `http.Handler`, and type assertions.
+
+## CLI Commands
+
+```bash
+the-gpl degrees --c=-20 --f=-20 --k=-20   # temperature flag interface
+the-gpl count --text="hello world go"      # counting writer interfaces
+```
+
+## Writer Interfaces
+
+Three types that all implement `io.Writer` by counting what passes through them:
+
+```go
+var b chapter7.ByteCounter
+fmt.Fprintf(&b, "Hello, world!")
+fmt.Println(b) // 13
+
+var w chapter7.WordCounter
+fmt.Fprintf(&w, "Hello, world Go")
+fmt.Println(w) // 3
+
+var l chapter7.LineCounter
+fmt.Fprintf(&l, "line1\nline2\nline3")
+fmt.Println(l) // 3
+```
+
+| Type | Counts | Underlying type |
+|---|---|---|
+| `ByteCounter` | bytes written | `int` |
+| `WordCounter` | whitespace-delimited words | `int` |
+| `LineCounter` | newline-terminated lines | `int` |
+
+### `CountWriter` — Wrapping an Existing Writer
+
+```go
+var buf bytes.Buffer
+cw, n := chapter7.CountingWriter(&buf)
+fmt.Fprintf(cw, "hello")
+fmt.Println(*n) // 5
+```
+
+`CountingWriter(w io.Writer) (io.Writer, *int64)` wraps any writer and returns a live
+byte count via a pointer — the counter updates as writes happen.
+
+### `BroadcastWriters` — Fan-out to Multiple Writers
+
+```go
+var a, b bytes.Buffer
+bw := chapter7.NewBroadcastWriters(&a, &b)
+fmt.Fprintf(bw, "broadcast")
+// a.String() == "broadcast", b.String() == "broadcast"
+```
+
+## Temperature Flag Interface
+
+`CelsiusFlag`, `FahrenheitFlag`, and `KelvinFlag` satisfy `flag.Value` so temperature
+types from `chapter2/tempConv` can be used directly as command-line flags:
+
+```go
+fs := flag.NewFlagSet("demo", flag.ContinueOnError)
+c := chapter7.CelsiusFlag("temp", 20, "temperature in Celsius", fs)
+fs.Parse([]string{"--temp=100"})
+fmt.Println(*c) // 100°C
+```
+
+```bash
+the-gpl degrees --c=100    # prints Celsius, Fahrenheit, Kelvin equivalents
+the-gpl degrees --f=212
+the-gpl degrees --k=373
+```
+
+## Character / Word / Line Counter
+
+```go
+r := strings.NewReader("hello\nworld\n")
+chars, words, lines := chapter7.CountCharsWordsLines(r)
+// chars=12, words=2, lines=2
+```
+
+```bash
+the-gpl count --text="The Go Programming Language"
+```
+
+## Running Tests
+
+```bash
+go test ./chapter7/...
+go test -v -run TestByteCounter ./chapter7/...
+```
+
+## Go Features Demonstrated
+
+- Interface definition and implicit satisfaction
+- `io.Writer` — the ubiquitous single-method interface
+- `flag.Value` — custom flag types via interface
+- Type embedding vs composition
+- `sort.Interface` (`Len`, `Less`, `Swap`)
+- `http.Handler` and `http.HandlerFunc`
+- Type assertions (`x.(T)`) and type switches
+- Named types on primitive kinds (`type ByteCounter int`)
+- Methods with pointer receivers satisfying interfaces

--- a/chapter8/README.md
+++ b/chapter8/README.md
@@ -1,0 +1,138 @@
+# Chapter 8 — Goroutines and Channels
+
+Examples from Chapter 8 of *The Go Programming Language*, covering the communicating
+sequential processes (CSP) model: goroutines, channels, `select`, and cancellation.
+
+## CLI Commands
+
+```bash
+# Services (start a server)
+the-gpl service -sp="clock:9999"    # TCP clock — broadcasts current time every second
+the-gpl service -sp="reverb:9998"   # TCP reverb — echoes back in SHOUT then fade
+the-gpl service -sp="chat:9997"     # TCP broadcast chat room
+the-gpl service -sp="ftp:9996"      # Minimal FTP server
+
+# Clients (connect to a server)
+the-gpl client -cp="clock:9999"
+the-gpl client -cp="reverb:9998"
+nc localhost 9997                    # netcat joins the chat room
+
+# Disk usage
+the-gpl du --dir=$HOME              # concurrent recursive disk usage
+the-gpl du --dir=. --verbose        # prints each directory size
+```
+
+## Services
+
+### Clock Server / Client
+
+```go
+go chapter8.ClockServer(9999)  // sends "15:04:05\n" every second
+chapter8.ClockClient(9999)     // prints received lines
+```
+
+Demonstrates: `net.Listen`, `net.Accept`, `goroutine per connection`, `time.Tick`.
+
+### Reverb Server / Client
+
+```go
+go chapter8.ReverbServer(9998)
+chapter8.ReverbClient(9998)
+```
+
+Echoes each line back three times: SHOUTED, normal, then quiet — each in a separate
+goroutine so multiple echoes overlap concurrently.
+
+### Chat Service
+
+```go
+go chapter8.ChatService(9997)
+```
+
+Multi-user broadcast chat. Three goroutines per connection (reader, writer, broadcaster)
+communicate via channels:
+
+```go
+var (
+    entering = make(chan client)
+    leaving  = make(chan client)
+    messages = make(chan string)
+)
+```
+
+Demonstrates: fan-in/fan-out channel patterns, `select`.
+
+### FTP Server
+
+```go
+go chapter8.FTPServer(9996)
+```
+
+Minimal FTP implementation for local connections. Demonstrates `bufio.Scanner`
+for line-oriented protocol parsing.
+
+## Concurrent Disk Usage (`DU`)
+
+```go
+size := chapter8.DU("/home/user", true)
+fmt.Printf("Total: %d bytes\n", size)
+```
+
+Walks a directory tree using up to `chapter8.MaxGoRoutines` parallel goroutines.
+A pipeline of channels connects the directory walker to the size accumulator,
+with a counting semaphore to bound concurrency.
+
+```
+walkDir → fileSizes chan → accumulator
+```
+
+## Web Search (`search/`)
+
+```go
+// HTTP handler — GET /search?q=golang&Timeout=3s
+search.Query(w, r)
+```
+
+Performs a parallel web search with a per-request timeout using `context`.
+
+### `search/google/`
+
+```go
+ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+defer cancel()
+results, err := google.Search(ctx, "Go programming")
+```
+
+`Result` struct: `Title`, `URL` fields. `Results` is a sortable slice.
+
+### `search/userip/`
+
+```go
+ip, err := userip.FromRequest(r)
+ctx := userip.NewContext(context.Background(), ip)
+ip2, ok := userip.FromContext(ctx)
+```
+
+Stores and retrieves client IP in a `context.Context` — a common production pattern
+for threading request metadata through a call stack.
+
+## Running Tests
+
+```bash
+go test ./chapter8/...
+go test -v ./chapter8/search/...
+```
+
+## Go Features Demonstrated
+
+- Goroutine lifecycle and `go` statement
+- Unbuffered channels for synchronisation
+- Buffered channels as semaphores (`make(chan struct{}, N)`)
+- `select` with `default` for non-blocking sends/receives
+- `context.Context` for cancellation and timeout propagation
+- `net.Listener` / `net.Conn` for TCP servers
+- `sync.WaitGroup` for goroutine fan-out
+- Pipeline pattern: producer → channel → consumer
+- Fan-out pattern: one channel, multiple readers
+- Fan-in pattern: multiple goroutines writing to one channel
+- `MaxGoRoutines` constant as a concurrency knob


### PR DESCRIPTION
## Summary

Creates `README.md` for all chapters that lacked one (4 already had one):

- `chapter1/README.md` — goroutines, channels, Lissajous, Dialogflow bot, Speech-to-Text
- `chapter2/README.md` — bit counting (three strategies), temperature conversion types
- `chapter3/README.md` — Mandelbrot PNG handlers, 3-D surface SVG plots, string utilities
- `chapter5/README.md` — HTML traversal, web crawler, topological sort, variadic min/max
- `chapter6/README.md` — IntSet bit-vector API, exercises
- `chapter7/README.md` — Writer interfaces, CountWriter, BroadcastWriters, temperature flag
- `chapter8/README.md` — TCP services, concurrent DU, web search with context

Each README follows the chapter4 pattern: concept overview, Go snippets, exercise list, run/test instructions.

## Test plan

- [ ] All 7 README files render correctly on GitHub
- [ ] `go build ./...` and `go test ./...` pass (no Go files changed)

Closes #5

---
_Generated by [Claude Code](https://claude.ai/code/session_012g3edjKRKYuy1PBNLfov96)_