### PR TITLE
feat: improve GoDoc comments across chapters

### DIFF
--- a/chapter1/chapter1.go
+++ b/chapter1/chapter1.go
@@ -1,3 +1,11 @@
-// Package chapter1, Tutorial, comprises miscellaneous examples.
-// It covers overview of channels. APIs, graphs, live caption using Google Speech to text etc.
+// Package chapter1 covers Chapter 1 of The Go Programming Language: A Tutorial.
+//
+// Sub-packages and what they demonstrate:
+//   - lissajous: animated GIF generation, HTTP handler pattern
+//   - channels:  concurrent HTTP fetch with goroutines and channels
+//   - mas:       maps, arrays, and string utilities
+//   - dup:       duplicate-line detection using a map counter
+//   - structs:   pointer vs value receivers on struct types
+//   - bot:       Dialogflow conversational-agent integration (requires GOOGLE_APPLICATION_CREDENTIALS)
+//   - livecaption: Google Speech-to-Text from an RTP/UDP audio stream
 package chapter1

--- a/chapter3/constants.go
+++ b/chapter3/constants.go
@@ -26,11 +26,13 @@ const (
 	MaxGoRoutines = 32
 )
 
+// MandelbrotImage selects the colour mode used by the Mandelbrot renderer.
 type MandelbrotImage int
 
 const (
-	// MBBlackAndWhite draws MB in Black and White
+	// MBBlackAndWhite renders the Mandelbrot set in greyscale (Exercise 3.5).
 	MBBlackAndWhite MandelbrotImage = iota
+	// MBColor renders the Mandelbrot set with RGB super-sampling anti-aliasing (Exercise 3.6).
 	MBColor
 )
 
@@ -61,6 +63,8 @@ const (
 )
 
 const (
-	EggDenominator     = 10
+	// EggDenominator scales the egg surface z-values to a visible range.
+	EggDenominator = 10
+	// SquaresDenominator scales the square-wave surface z-values to a visible range.
 	SquaresDenominator = 5
 )

--- a/chapter3/mandelbrot.go
+++ b/chapter3/mandelbrot.go
@@ -76,13 +76,17 @@ func mandelbrot(z complex128, b MandelbrotImage) color.Color {
 	return color.Black
 }
 
-// MBGraphHandler returns a color image.
+// MBGraphHandler is an HTTP handler that writes a colour Mandelbrot PNG to w.
+// Registered at GET /mandelimage.png; rendered in the browser via /mandel.
 func MBGraphHandler(w http.ResponseWriter, _ *http.Request) { mandelbrotImage(w, MBColor) }
 
-// MBGraphBWHandler in black
+// MBGraphBWHandler is an HTTP handler that writes a greyscale Mandelbrot PNG to w.
+// Registered at GET /mandelbwimage.png; rendered in the browser via /mandelbw.
 func MBGraphBWHandler(w http.ResponseWriter, _ *http.Request) { mandelbrotImage(w, MBBlackAndWhite) }
 
-// SetColor total at subsequent z for ith iteration
+// SetColor accumulates RGB colour components for a Mandelbrot pixel.
+// z is the complex number at the pixel, iteration is the escape depth.
+// Called once per sub-pixel sample; the caller averages MBSubPixels samples.
 func (cp *colorComponents) SetColor(z complex128, iteration float64) {
 	f := cmplx.Abs(z) / maxAmp // fraction
 	cp.blue += f * MBContrast * iteration

--- a/chapter3/surface.go
+++ b/chapter3/surface.go
@@ -84,38 +84,38 @@ func Sinc(x, y float64) float64 {
 	return k
 }
 
-// Squares of sorts
+// Squares returns a square-wave grid surface: (sin(x/π) + cos(y/π))² / SquaresDenominator.
 func Squares(x, y float64) float64 {
 	return math.Pow(math.Sin(x/math.Pi)+math.Cos(y/math.Pi), 2) / SquaresDenominator
 }
 
-// Valley of sorts
+// Valley returns a saddle/valley surface: sin(−y) · 2^(−hypot(x,y)).
 func Valley(x, y float64) float64 {
 	r := math.Hypot(x, y) // Distance of (x,y) from (0,0)
 	return math.Sin(-y) * math.Pow(2, -r)
 }
 
-// Egg sampling function returns squares
+// Egg returns an egg-carton surface: 2^sin(x) · 2^cos(y) / EggDenominator.
 func Egg(x, y float64) float64 {
 	return math.Pow(2, math.Sin(x)) * math.Pow(2, math.Cos(y)) / EggDenominator
 }
 
-// EggHandlerSVG draws an egg on a writer
+// EggHandlerSVG writes an egg-carton 3-D surface as SVG to w. Served at /eggSVG.svg.
 func EggHandlerSVG(w io.Writer) {
 	PlotOn3DSurface(w, Egg)
 }
 
-// SincSVG writes raw SVG content
+// SincSVG writes a sinc (sin(r)/r) 3-D surface as SVG to w. Served at /sincSVG.svg.
 func SincSVG(w io.Writer) {
 	PlotOn3DSurface(w, Sinc)
 }
 
-// ValleyHandlerSVG draws a Valley on a writer
+// ValleyHandlerSVG writes a valley/saddle 3-D surface as SVG to w. Served at /valleySVG.svg.
 func ValleyHandlerSVG(w io.Writer) {
 	PlotOn3DSurface(w, Valley)
 }
 
-// SquaresHandlerSVG draws a sinc on a writer
+// SquaresHandlerSVG writes a square-wave grid 3-D surface as SVG to w. Served at /sqSVG.svg.
 func SquaresHandlerSVG(w io.Writer) {
 	PlotOn3DSurface(w, Squares)
 }

--- a/chapter5/ch5.go
+++ b/chapter5/ch5.go
@@ -1,4 +1,7 @@
-// Package chapter5 is Functions, covers examples and exercises in the chapter.
+// Package chapter5 covers Chapter 5 of The Go Programming Language: Functions.
+//
+// Demonstrates recursion, first-class functions, closures, variadic arguments,
+// multiple return values, and error handling through HTML parsing and web crawling examples.
 package chapter5
 
 import (
@@ -8,7 +11,8 @@ import (
 	"golang.org/x/net/html"
 )
 
-// E51FindLinks Exercise 5.1 make  links using traversal non-loop recursive
+// E51FindLinks collects all href values from the HTML parse tree rooted at n.
+// Uses recursive traversal (FirstChild + NextSibling) instead of a loop. Exercise 5.1.
 func E51FindLinks(href []string, n *html.Node) []string {
 	if n == nil { // Terminal node reached. Return
 		return href
@@ -82,7 +86,8 @@ func endElement(n *html.Node) {
 	}
 }
 
-// Expand exercise 5.9 replaces $var with f(var) and returns output
+// Expand replaces each $var token in s by calling f("var") and returns the result.
+// Exercise 5.9.
 func Expand(s string, f func(string) string) string {
 	chars := strings.Split(s, " ")
 	for i, word := range chars {

--- a/chapter6/intset.go
+++ b/chapter6/intset.go
@@ -153,7 +153,8 @@ func (s *IntSet) Remove(x uint) {
 	}
 }
 
-// IntersectWith Exercise 6.3  Implement methods for IntersectWith
+// IntersectWith returns a new IntSet containing elements present in both s and t (s ∩ t).
+// Exercise 6.3.
 func (s *IntSet) IntersectWith(t *IntSet) *IntSet {
 	r := New()
 	for _, v := range t.Elements() {
@@ -164,7 +165,8 @@ func (s *IntSet) IntersectWith(t *IntSet) *IntSet {
 	return r
 }
 
-// DifferenceWith Exercise 6.3  Implement methods for DifferenceWith
+// DifferenceWith returns a new IntSet of elements in t but not in s (t − s).
+// Exercise 6.3.
 func (s *IntSet) DifferenceWith(t *IntSet) *IntSet {
 	r := New()
 	for _, v := range t.Elements() {
@@ -175,7 +177,8 @@ func (s *IntSet) DifferenceWith(t *IntSet) *IntSet {
 	return r
 }
 
-// SymmetricDifference Exercise 6.3  Implement methods for SymmetricDifference
+// SymmetricDifference returns a new IntSet of elements in either s or t but not both ((s ∪ t) − (s ∩ t)).
+// Exercise 6.3.
 func (s *IntSet) SymmetricDifference(t *IntSet) *IntSet {
 	r := s.Copy()
 	r.UnionWith(t)
@@ -195,7 +198,7 @@ func (s *IntSet) Clear() {
 	s.list = list.New()
 }
 
-// UnionWith create a union of set s with IntSet (t). Not thread safe
+// UnionWith adds all elements of t into s in place (s ∪= t). Not thread-safe.
 func (s *IntSet) UnionWith(t *IntSet) {
 	// Iterate for all elements of input union list
 	for element := t.list.Front(); element != nil; element = element.Next() {
@@ -234,14 +237,12 @@ func (s *IntSet) UnionWith(t *IntSet) {
 	}
 }
 
-// Len returns length of a set by counting number of 1-bits
-//
-//	Exercise 6.1: Add (*IntSet)Len()
+// Len returns the number of elements in the set. Exercise 6.1.
 func (s *IntSet) Len() int {
 	return s.count
 }
 
-// Copy returns copy of set Exercise 6.1
+// Copy returns a deep copy of the set. Exercise 6.1.
 func (s *IntSet) Copy() *IntSet {
 	if s == nil {
 		return nil
@@ -252,9 +253,7 @@ func (s *IntSet) Copy() *IntSet {
 	return c
 }
 
-// Elements returns a slice of all integers in the set
-//
-//	Exercise 6.4: Add a method Elements that returns a slice containing the
+// Elements returns a sorted slice of all integers in the set. Exercise 6.4.
 func (s *IntSet) Elements() []uint {
 	var set []uint
 	if s == nil {

--- a/chapter8/common.go
+++ b/chapter8/common.go
@@ -1,3 +1,7 @@
+// Package chapter8 covers Chapter 8 of The Go Programming Language: Goroutines and Channels.
+//
+// It provides TCP services (clock, reverb, chat, FTP), a concurrent disk-usage
+// utility (DU), and a parallel web search — all demonstrating Go's CSP concurrency model.
 package chapter8
 
 import (

--- a/chapter8/du.go
+++ b/chapter8/du.go
@@ -22,8 +22,10 @@ import (
 //    Solution 2: Implement cancel mechanism using separate  cancel or done channel.
 //			The sender go-routines monitor it and stop further processing if 'done' is closed.
 
-const MaxOpenFiles = 1024 // Reduce number of open system files
-// MaxGoRoutines number of parallel go-routines
+// MaxOpenFiles caps the total open file descriptors used by DU.
+const MaxOpenFiles = 1024
+
+// MaxGoRoutines is the concurrency limit for parallel walkDir goroutines (MaxOpenFiles / 2).
 const MaxGoRoutines = MaxOpenFiles / 2
 
 var sema = make(chan struct{}, MaxGoRoutines) // sema counting semaphore to  run
@@ -61,7 +63,8 @@ func dirEntry(dir string) []os.DirEntry {
 	return entries
 }
 
-// DU Disk Usage returns size of a directory
+// DU returns the total byte size of all files under dir, using up to MaxGoRoutines
+// parallel goroutines. When verbose is true it prints a running summary every second.
 func DU(dir string, verbose bool) int64 {
 	sizes := make(chan int64, MaxOpenFiles) // Create c channel that holds sizes for MaxOpenFiles files max
 	wg.Add(1)

--- a/chapter8/search/google/google.go
+++ b/chapter8/search/google/google.go
@@ -1,4 +1,6 @@
-// Package google implements a Search using a deprecated API.
+// Package google implements a web search using the deprecated Google AJAX Search API.
+// Demonstrates context propagation, HTTP cancellation, and goroutine-based fan-out
+// as shown in Chapter 8 of The Go Programming Language.
 package google
 
 import (
@@ -11,12 +13,12 @@ import (
 	"net/http"
 )
 
-// Result a search result
+// Result holds the title and URL of a single web search result.
 type Result struct {
 	Title, URL string
 }
 
-// Results array of results
+// Results is a slice of Result values returned by Search.
 type Results []Result
 
 // Search sends a query to Google API along with userIP and returns result.

--- a/chapter8/search/userip/userip.go
+++ b/chapter8/search/userip/userip.go
@@ -1,4 +1,6 @@
-// Package userip is similar to golang.org/x/blog/content/context/userip
+// Package userip stores and retrieves a client's IP address in a context.Context.
+// This is the canonical pattern for threading request-scoped values through a call stack
+// without extending every function signature. Modelled after golang.org/x/blog/content/context/userip.
 package userip
 
 import (
@@ -14,7 +16,7 @@ type key int
 // userIPKey where userIP is stored
 const userIPKey key = 0
 
-// FromRequest gets the userIP from a request
+// FromRequest extracts the client IP address from req.RemoteAddr.
 func FromRequest(req *http.Request) (net.IP, error) {
 	ip, _, err := net.SplitHostPort(req.RemoteAddr)
 	if err != nil {
@@ -27,12 +29,12 @@ func FromRequest(req *http.Request) (net.IP, error) {
 	return userIP, nil
 }
 
-// NewContext creates a new context with request scoped value ["0"]: "IP"
+// NewContext returns a copy of ctx with userIP stored under the package-private key.
 func NewContext(ctx context.Context, userIP net.IP) context.Context {
 	return context.WithValue(ctx, userIPKey, userIP)
 }
 
-// FromContext gets  the value from ctx
+// FromContext retrieves the IP address stored by NewContext. ok is false if none was set.
 func FromContext(ctx context.Context) (net.IP, bool) {
 	// ctx.Value returns nil if ctx has no value for "userIPKey"
 	// net.IP assertion return ok=false for nil


### PR DESCRIPTION
## Summary

Adds or expands GoDoc comments on exported symbols across chapters 1, 3, 5, 6, and 8:

- `chapter1/chapter1.go` — package-level doc listing all sub-packages
- `chapter3/constants.go` — `MandelbrotImage` type, `MBBlackAndWhite`/`MBColor` (Exercise 3.5/3.6), `EggDenominator`, `SquaresDenominator`
- `chapter3/mandelbrot.go` — `MBGraphHandler`, `MBGraphBWHandler`, `SetColor` with parameter docs
- `chapter3/surface.go` — `Squares`, `Valley`, `Egg`, SVG handlers with route info
- `chapter5/ch5.go` — `E51FindLinks` (Exercise 5.1), `Expand` (Exercise 5.9)
- `chapter6/intset.go` — `IntersectWith`, `DifferenceWith`, `SymmetricDifference`, `Len`, `Copy`, `Elements`, `UnionWith`
- `chapter8/common.go` — package-level doc
- `chapter8/du.go` — `MaxOpenFiles`, `MaxGoRoutines`, `DU`
- `chapter8/search/google/google.go` — package doc, `Result`, `Results`
- `chapter8/search/userip/userip.go` — package doc, `FromRequest`, `NewContext`, `FromContext`

## Test plan

- [ ] `go build ./...` passes
- [ ] `go vet ./...` passes
- [ ] `go doc` output is improved for all listed symbols

Closes #6

---
_Generated by [Claude Code](https://claude.ai/code/session_012g3edjKRKYuy1PBNLfov96)_