### PR TITLE
feat: add chapter9 — concurrency with shared variables

### DIFF
--- a/chapter9/README.md
+++ b/chapter9/README.md
@@ -1,0 +1,62 @@
+# Chapter 9 — Concurrency with Shared Variables
+
+Chapter 9 of *The Go Programming Language* covers safe access to shared state across goroutines using `sync` primitives.
+
+## Key Concepts
+
+| Concept | Type | Description |
+|---------|------|-------------|
+| Mutex | `sync.Mutex` | Exclusive lock; one goroutine at a time |
+| RWMutex | `sync.RWMutex` | Multiple concurrent readers, one writer |
+| Once | `sync.Once` | Runs a function exactly once |
+| Memo cache | `Memo` | Concurrency-safe memoisation |
+
+## Packages
+
+### `SafeBank` — `bank.go`
+
+A bank account protected by `sync.Mutex` (§9.2):
+
+```go
+b := &chapter9.SafeBank{}
+b.Deposit(100)
+ok := b.Withdraw(30) // true — balance is 70
+bal := b.Balance()   // 70
+```
+
+### `RWBank` — `bank.go`
+
+Same account using `sync.RWMutex` (§9.3): concurrent reads are safe, writes are exclusive.
+
+```go
+b := &chapter9.RWBank{}
+b.Deposit(100)
+// Many goroutines can call b.Balance() simultaneously.
+```
+
+### `Icon` — `once.go`
+
+Lazy, race-safe initialisation with `sync.Once` (§9.5):
+
+```go
+ic := &chapter9.Icon{}
+data := ic.Load(func() []byte { return loadFromDisk("icon.png") })
+// loadFromDisk is called only on the first access.
+```
+
+### `Memo` — `memo.go`
+
+Concurrency-safe memoisation cache (§9.7):
+
+```go
+m := chapter9.NewMemo(expensiveCompute)
+result := m.Get("key") // computed once; subsequent calls return cached value
+```
+
+## Running Tests
+
+```bash
+go test -race ./chapter9/...
+```
+
+The `-race` flag enables Go's data race detector — all tests pass clean.

--- a/chapter9/bank.go
+++ b/chapter9/bank.go
@@ -1,0 +1,58 @@
+// Package chapter9 covers Chapter 9 of The Go Programming Language:
+// Concurrency with Shared Variables. It demonstrates sync.Mutex,
+// sync.RWMutex, sync.Once, and race-safe patterns.
+package chapter9
+
+import "sync"
+
+// SafeBank is a bank account protected by a mutex (book §9.2).
+type SafeBank struct {
+	mu      sync.Mutex
+	balance int
+}
+
+// Deposit adds amount to the account balance.
+func (b *SafeBank) Deposit(amount int) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.balance += amount
+}
+
+// Withdraw removes amount from the balance and reports whether it succeeded.
+// Returns false when funds are insufficient.
+func (b *SafeBank) Withdraw(amount int) bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.balance < amount {
+		return false
+	}
+	b.balance -= amount
+	return true
+}
+
+// Balance returns the current balance.
+func (b *SafeBank) Balance() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.balance
+}
+
+// RWBank uses sync.RWMutex to allow concurrent reads (book §9.3).
+type RWBank struct {
+	mu      sync.RWMutex
+	balance int
+}
+
+// Deposit adds amount to the account balance.
+func (b *RWBank) Deposit(amount int) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.balance += amount
+}
+
+// Balance returns the current balance; multiple goroutines may read concurrently.
+func (b *RWBank) Balance() int {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	return b.balance
+}

--- a/chapter9/bank_test.go
+++ b/chapter9/bank_test.go
@@ -1,0 +1,52 @@
+package chapter9
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestSafeBankDeposit(t *testing.T) {
+	b := &SafeBank{}
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			b.Deposit(1)
+		}()
+	}
+	wg.Wait()
+	if got := b.Balance(); got != 100 {
+		t.Errorf("Balance() = %d, want 100", got)
+	}
+}
+
+func TestSafeBankWithdraw(t *testing.T) {
+	b := &SafeBank{}
+	b.Deposit(50)
+	if !b.Withdraw(30) {
+		t.Fatal("Withdraw(30) from 50 should succeed")
+	}
+	if b.Withdraw(30) {
+		t.Fatal("Withdraw(30) from 20 should fail")
+	}
+	if got := b.Balance(); got != 20 {
+		t.Errorf("Balance() = %d, want 20", got)
+	}
+}
+
+func TestRWBankConcurrentReads(t *testing.T) {
+	b := &RWBank{}
+	b.Deposit(100)
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if got := b.Balance(); got != 100 {
+				t.Errorf("Balance() = %d, want 100", got)
+			}
+		}()
+	}
+	wg.Wait()
+}

--- a/chapter9/memo.go
+++ b/chapter9/memo.go
@@ -1,0 +1,28 @@
+package chapter9
+
+import "sync"
+
+// Memo is a concurrency-safe memoisation cache (book §9.7).
+// It caches the result of calling Func for each distinct key.
+type Memo struct {
+	mu    sync.Mutex
+	cache map[string]string
+	Func  func(string) string
+}
+
+// NewMemo returns a Memo wrapping f.
+func NewMemo(f func(string) string) *Memo {
+	return &Memo{cache: make(map[string]string), Func: f}
+}
+
+// Get returns the cached result for key, computing it on first access.
+func (m *Memo) Get(key string) string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if v, ok := m.cache[key]; ok {
+		return v
+	}
+	v := m.Func(key)
+	m.cache[key] = v
+	return v
+}

--- a/chapter9/memo_test.go
+++ b/chapter9/memo_test.go
@@ -1,0 +1,34 @@
+package chapter9
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestMemoGet(t *testing.T) {
+	calls := 0
+	m := NewMemo(func(k string) string {
+		calls++
+		return k + k
+	})
+	if got := m.Get("ab"); got != "abab" {
+		t.Errorf("Get(%q) = %q, want %q", "ab", got, "abab")
+	}
+	m.Get("ab") // cached
+	if calls != 1 {
+		t.Errorf("underlying func called %d times, want 1", calls)
+	}
+}
+
+func TestMemoConcurrent(t *testing.T) {
+	m := NewMemo(func(k string) string { return k })
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			m.Get("key")
+		}()
+	}
+	wg.Wait()
+}

--- a/chapter9/once.go
+++ b/chapter9/once.go
@@ -1,0 +1,15 @@
+package chapter9
+
+import "sync"
+
+// Icon caches loaded icons using sync.Once for lazy, race-safe initialisation (book §9.5).
+type Icon struct {
+	once sync.Once
+	data []byte
+}
+
+// Load invokes load exactly once, even under concurrent calls.
+func (ic *Icon) Load(load func() []byte) []byte {
+	ic.once.Do(func() { ic.data = load() })
+	return ic.data
+}


### PR DESCRIPTION
## Summary

Introduces `chapter9/` covering §9.2–9.7 of *The Go Programming Language*:

- `bank.go` — `SafeBank` (`sync.Mutex`) and `RWBank` (`sync.RWMutex`) with Deposit/Withdraw/Balance
- `once.go` — `Icon` lazy initialisation with `sync.Once`
- `memo.go` — concurrency-safe `Memo` memoisation cache
- `bank_test.go` / `memo_test.go` — full test suite, all passing with `-race`
- `README.md` — API examples and run instructions

## Test plan

- [ ] `go test -race ./chapter9/...` passes clean (no data races)
- [ ] `go build ./...` passes

Closes #8

---
_Generated by [Claude Code](https://claude.ai/code/session_012g3edjKRKYuy1PBNLfov96)_