### PR TITLE
feat: modernize code — %w wrapping, slog, generics

### DIFF
--- a/chapter1/channels/channels.go
+++ b/chapter1/channels/channels.go
@@ -56,12 +56,12 @@ func FetchTimeInfo(url string, ch chan<- string) {
 func Fetch(url string) (string, error) {
 	resp, err := http.Get(url)
 	if err != nil {
-		return "", fmt.Errorf("err: %v", err)
+		return "", fmt.Errorf("err: %w", err)
 	}
 	data, err := io.ReadAll(resp.Body)
 	_ = resp.Body.Close()
 	if err != nil {
-		return "", fmt.Errorf("parse err: %v", err)
+		return "", fmt.Errorf("parse err: %w", err)
 	}
 	if resp.StatusCode != http.StatusOK {
 		return "", fmt.Errorf("invalid status: %v", resp.Status)

--- a/chapter3/surface.go
+++ b/chapter3/surface.go
@@ -24,7 +24,7 @@ func PlotOn3DSurface(w io.Writer, plot func(float64, float64) float64) {
 	// close SVG tag in all returns
 	defer (func() { _, _ = fmt.Fprintf(w, "\n%s\n", SVGSuffixTag) })()
 	if err != nil {
-		_ = fmt.Errorf("PlotOn3DSurface: Error: %s", err)
+		slog.Error("PlotOn3DSurface", "err", err)
 		return
 	}
 

--- a/chapter5/generics.go
+++ b/chapter5/generics.go
@@ -1,0 +1,29 @@
+package chapter5
+
+import "cmp"
+
+// MaxOf returns the maximum of the provided values.
+// Requires at least one argument; panics on empty call.
+// Generic replacement for MaxInt/MaxIntOf (Exercise 5.15).
+func MaxOf[T cmp.Ordered](n1 T, rest ...T) T {
+	m := n1
+	for _, v := range rest {
+		if v > m {
+			m = v
+		}
+	}
+	return m
+}
+
+// MinOf returns the minimum of the provided values.
+// Requires at least one argument; panics on empty call.
+// Generic replacement for MinInt/MinIntOf (Exercise 5.15).
+func MinOf[T cmp.Ordered](n1 T, rest ...T) T {
+	m := n1
+	for _, v := range rest {
+		if v < m {
+			m = v
+		}
+	}
+	return m
+}

--- a/chapter5/generics_test.go
+++ b/chapter5/generics_test.go
@@ -1,0 +1,24 @@
+package chapter5
+
+import "testing"
+
+func TestMaxOf(t *testing.T) {
+	if got := MaxOf(3, 1, 4, 1, 5, 9, 2); got != 9 {
+		t.Errorf("MaxOf(ints) = %d, want 9", got)
+	}
+	if got := MaxOf(3.14, 2.71, 1.41); got != 3.14 {
+		t.Errorf("MaxOf(floats) = %v, want 3.14", got)
+	}
+	if got := MaxOf("banana", "apple", "cherry"); got != "cherry" {
+		t.Errorf("MaxOf(strings) = %q, want %q", got, "cherry")
+	}
+}
+
+func TestMinOf(t *testing.T) {
+	if got := MinOf(3, 1, 4, 1, 5); got != 1 {
+		t.Errorf("MinOf(ints) = %d, want 1", got)
+	}
+	if got := MinOf(3.14, 2.71, 1.41); got != 1.41 {
+		t.Errorf("MinOf(floats) = %v, want 1.41", got)
+	}
+}

--- a/chapter8/search/search.go
+++ b/chapter8/search/search.go
@@ -51,7 +51,7 @@ func Query(w http.ResponseWriter, req *http.Request) {
 	start := time.Now()
 	results, err := google.Search(ctx, q)
 	if err != nil {
-		errMessage := fmt.Errorf("google search API is deprecated: %v", err)
+		errMessage := fmt.Errorf("google search API is deprecated: %w", err)
 		http.Error(w, errMessage.Error(), http.StatusInternalServerError)
 		return
 	}


### PR DESCRIPTION
## Summary

- `chapter1/channels/channels.go` — replace `%v` with `%w` in `fmt.Errorf` calls so errors are properly unwrappable
- `chapter3/surface.go` — replace silent `_ = fmt.Errorf(...)` with `slog.Error(...)` for structured logging
- `chapter8/search/search.go` — replace `%v` with `%w` in error wrap
- `chapter5/generics.go` — add `MaxOf[T cmp.Ordered]` and `MinOf[T cmp.Ordered]` generic functions as modern replacements for the four int-specific variadic functions (Exercise 5.15)
- `chapter5/generics_test.go` — tests covering `int`, `float64`, and `string`

## Test plan

- [ ] `go build ./...` passes
- [ ] `go vet ./...` passes
- [ ] `go test -run "TestMaxOf|TestMinOf" ./chapter5/...` passes
- [ ] `go test ./chapter3/... ./chapter8/...` passes

Closes #9

---
_Generated by [Claude Code](https://claude.ai/code/session_012g3edjKRKYuy1PBNLfov96)_