### PR TITLE
feat: compact mobile nav — horizontal-scroll strip

### DIFF
--- a/public/css/initial/navflex.css
+++ b/public/css/initial/navflex.css
@@ -56,20 +56,39 @@
     color: #000000 !important;
 }
 
-/* Responsive cards */
+/* Mobile: single horizontal-scroll strip instead of vertical stack */
 @media screen and (max-width: 600px) {
     .flex-navigation {
-        flex-flow: column;
+        flex-flow: row nowrap;
+        overflow-x: auto;
+        -webkit-overflow-scrolling: touch;
+    }
+
+    /* hide scrollbar track — tabs still swipeable */
+    .flex-navigation::-webkit-scrollbar {
+        display: none;
     }
 
     .flex-nav-tab {
-        width: 100%;
+        width: auto;
+        flex-shrink: 0;
+    }
+
+    .flex-nav-tab a {
+        padding: 8px 10px;
+        font-size: 0.85rem;
+        white-space: nowrap;
+    }
+
+    /* spacer has no effect in a nowrap row — hide it */
+    .flex-nav-tab-last-spacer {
+        display: none;
     }
 
     .flex-nav-tab-last {
-        border-left: none;
+        border-left: 1px solid #bbb;
         border-right: none;
-        border-bottom: 3px solid #bbb;;
-        align-self: stretch;
+        border-bottom: none;
+        align-self: auto;
     }
 }


### PR DESCRIPTION
## Summary

On mobile (≤600px) the nav previously stacked 9 tabs vertically at 14px padding each, consuming ~540px before any content was visible. Pure CSS fix — no JS, desktop unchanged.

**`public/css/initial/navflex.css`** — replaces the `@media (max-width: 600px)` block:

- `flex-flow: row nowrap` + `overflow-x: auto` — single swipeable horizontal line
- Link padding reduced to `8px 10px`, font `0.85rem` — strip height ~36px (was ~540px)
- `-webkit-overflow-scrolling: touch` for iOS momentum scroll
- Scrollbar hidden visually via `::-webkit-scrollbar { display: none }`
- `flex-nav-tab-last-spacer` hidden (no-op in nowrap row)
- Desktop (>600px) completely unchanged

## Test plan

- [ ] Chrome DevTools mobile emulation (390px): nav is a single slim row, content visible immediately; all tabs reachable by horizontal swipe
- [ ] Desktop (1280px): nav looks identical to before — horizontal tab bar, full 14px padding, "About" right-aligned
- [ ] Active tab yellow highlight still visible on mobile

Closes #11

---
_Generated by [Claude Code](https://claude.ai/code/session_012g3edjKRKYuy1PBNLfov96)_