### PR TITLE
feat: white text on dark pages + hamburger nav for mobile/tablet

### DIFF
--- a/public/css/initial/main.css
+++ b/public/css/initial/main.css
@@ -12,9 +12,13 @@ body {
     opacity: 0.8;
     font-family: 'Roboto', sans-serif;
 }
-/*h3, h4 in index.html and other pages */
-h3, h4 {
+/* headings on all pages */
+h1, h2, h3, h4 {
     color: #ffffff;
     text-align: center;
     margin: 0.5rem auto;
+}
+/* body text on dark background */
+main p {
+    color: #e8e8e8;
 }

--- a/public/css/initial/navflex.css
+++ b/public/css/initial/navflex.css
@@ -56,39 +56,48 @@
     color: #000000 !important;
 }
 
-/* Mobile: single horizontal-scroll strip instead of vertical stack */
-@media screen and (max-width: 600px) {
-    .flex-navigation {
-        flex-flow: row nowrap;
-        overflow-x: auto;
-        -webkit-overflow-scrolling: touch;
+/* Hamburger button — hidden on desktop */
+.nav-hamburger { display: none; }
+
+/* Mobile/tablet: hamburger toggle menu at ≤900px */
+@media screen and (max-width: 900px) {
+    .nav-hamburger {
+        display: block;
+        width: 100%;
+        background: #333;
+        color: white;
+        border: none;
+        border-top: 1px solid #555;
+        font-size: 1.3rem;
+        padding: 10px 16px;
+        text-align: left;
+        cursor: pointer;
+        letter-spacing: 0.05em;
+    }
+    .nav-hamburger:hover {
+        background: #444;
     }
 
-    /* hide scrollbar track — tabs still swipeable */
-    .flex-navigation::-webkit-scrollbar {
+    .flex-navigation {
         display: none;
+        flex-flow: column nowrap;
+    }
+    .flex-navigation.nav-open {
+        display: flex;
     }
 
     .flex-nav-tab {
-        width: auto;
-        flex-shrink: 0;
-    }
-
-    .flex-nav-tab a {
-        padding: 8px 10px;
-        font-size: 0.85rem;
-        white-space: nowrap;
-    }
-
-    /* spacer has no effect in a nowrap row — hide it */
-    .flex-nav-tab-last-spacer {
-        display: none;
-    }
-
-    .flex-nav-tab-last {
-        border-left: 1px solid #bbb;
+        width: 100%;
         border-right: none;
+        border-bottom: 1px solid #444;
+    }
+    .flex-nav-tab a {
+        text-align: left;
+        padding: 12px 20px;
+    }
+    .flex-nav-tab-last-spacer { display: none; }
+    .flex-nav-tab-last {
+        border-left: none;
         border-bottom: none;
-        align-self: auto;
     }
 }

--- a/public/templates/chapters.gohtml
+++ b/public/templates/chapters.gohtml
@@ -13,21 +13,21 @@
             padding: 1.5rem;
         }
         .chapter-card {
-            border: 1px solid #ccc;
+            border: 1px solid #555;
             border-radius: 6px;
             padding: 1rem 1.2rem;
-            background: #fafafa;
+            background: #2a2433;
         }
-        .chapter-card h3 { margin: 0 0 0.4rem; font-size: 1.05rem; }
-        .chapter-card p  { margin: 0; font-size: 0.9rem; color: #444; }
-        .chapter-card a  { text-decoration: none; color: inherit; }
-        .chapter-card:hover { box-shadow: 0 2px 8px rgba(0,0,0,0.12); }
+        .chapter-card h3 { margin: 0 0 0.4rem; font-size: 1.05rem; color: #e8e8e8; text-align: left; }
+        .chapter-card p  { margin: 0; font-size: 0.9rem; color: #b0b0b0; }
+        .chapter-card a  { text-decoration: none; color: #7ab3f7; }
+        .chapter-card:hover { box-shadow: 0 2px 12px rgba(0,0,0,0.4); border-color: #7ab3f7; }
     </style>
 </head>
 <body>
 {{template "navflex" .Active}}
 <main role="main">
-    <section style="padding:1rem 1.5rem">
+    <section style="padding:1rem 1.5rem; color:#e8e8e8">
         <h2>Book Chapters</h2>
         <p>Each chapter mirrors a chapter from <em>The Go Programming Language</em> by Donovan &amp; Kernighan.</p>
     </section>

--- a/public/templates/navflex.gohtml
+++ b/public/templates/navflex.gohtml
@@ -3,8 +3,9 @@
         <!--- Quote at top of every page -->
         <q class="the-gpl-header-title" cite="https://blacklivesmatter.com/">Black Lives Matter</q>
         <header class="the-gpl-header">
+            <button class="nav-hamburger" id="navToggle" aria-label="Menu" aria-expanded="false">&#9776; Menu</button>
             <!--- Navigation bar, . is name of Active page  -->
-            <nav class="flex-navigation">
+            <nav class="flex-navigation" id="flexNav">
                 <div class="flex-nav-tab"><a{{if eq . "post"}} class="flex-nav-active" {{end}} href="post">Post Data</a></div>
                 <div class="flex-nav-tab"><a{{if eq . "lis"}} class="flex-nav-active" {{end}} href="lis">Lissajous</a></div>
                 <div class="flex-nav-tab"><a{{if eq . "sinc"}} class="flex-nav-active" {{end}} href="sinc">Sinc</a></div>
@@ -18,4 +19,16 @@
             </nav>
         </header>
     </aside>
+    <script>
+    (function(){
+        var btn = document.getElementById('navToggle');
+        var nav = document.getElementById('flexNav');
+        if (!btn || !nav) return;
+        btn.addEventListener('click', function() {
+            var open = nav.classList.toggle('nav-open');
+            btn.setAttribute('aria-expanded', String(open));
+            btn.innerHTML = open ? '&#10005; Close' : '&#9776; Menu';
+        });
+    })();
+    </script>
 {{end}}


### PR DESCRIPTION
## Summary

- **Closes #24** — `h1`/`h2` headings and `<p>` body text are now white/light on all pages. Extended `main.css` to cover `h1, h2` (was only `h3, h4`). Added `main p { color: #e8e8e8 }`. Chapter cards switched to dark theme (`#2a2433` background, `#7ab3f7` blue links, light text) to match the site palette.

- **Closes #25** — Replaced the wrapping multi-row nav with a hamburger toggle menu at ≤900px. On narrow screens a `☰ Menu` button appears; tapping it expands a vertical dropdown of all nav links; tapping again (or navigating) closes it. Breakpoint raised from 600px to 900px to cover tablets and landscape phones. Pure vanilla JS (~10 lines), no library.

## Files changed

| File | Change |
|---|---|
| `public/css/initial/main.css` | Add `h1, h2` to heading rule; add `main p` color |
| `public/templates/chapters.gohtml` | Dark-theme cards; light section text |
| `public/css/initial/navflex.css` | Replace scroll-strip `@media` block with hamburger CSS at ≤900px |
| `public/templates/navflex.gohtml` | Add `☰ Menu` button + toggle script |

## Test plan

- [ ] `go build ./...` passes
- [ ] Open `/chapters` — heading and card text white/light; cards dark
- [ ] Open `/ask-page` — "Go Tutor" h2 and intro `<p>` visible in white
- [ ] Resize to ≤900px — horizontal nav gone; `☰ Menu` button appears; tap toggles dropdown; `✕ Close` dismisses it
- [ ] At >900px — hamburger hidden, horizontal tab bar unchanged

---
_Generated by [Claude Code](https://claude.ai/code/session_012g3edjKRKYuy1PBNLfov96)_