### PR TITLE
Switch aitutor model to claude-sonnet-4-5

### DIFF
--- a/aitutor/tutor.go
+++ b/aitutor/tutor.go
@@ -27,7 +27,7 @@ func Ask(question, chapterContext string) (string, error) {
 	}
 
 	msg, err := client.Messages.New(context.Background(), anthropic.MessageNewParams{
-		Model:     anthropic.ModelClaudeOpus4_8,
+		Model:     anthropic.ModelClaudeSonnet4_5,
 		MaxTokens: 1024,
 		System: []anthropic.TextBlockParam{
 			{Text: systemPrompt},


### PR DESCRIPTION
Closes #35

## Summary

- `aitutor/tutor.go`: `anthropic.ModelClaudeOpus4_8` → `anthropic.ModelClaudeSonnet4_5`

Reduces per-call cost while maintaining sufficient quality for Go tutoring.


---
_Generated by [Claude Code](https://claude.ai/code/session_012g3edjKRKYuy1PBNLfov96)_