### PR TITLE
feat: switch aitutor to Haiku 4.5 (cheapest model)

### DIFF
--- a/aitutor/tutor.go
+++ b/aitutor/tutor.go
@@ -30,7 +30,7 @@ func Ask(question, chapterContext string) (string, error) {
 	}
 
 	msg, err := client.Messages.New(ctx, anthropic.MessageNewParams{
-		Model:     anthropic.ModelClaudeSonnet4_5,
+		Model:     anthropic.ModelClaudeHaiku4_5,
 		MaxTokens: 1024,
 		System: []anthropic.TextBlockParam{
 			{Text: systemPrompt},


### PR DESCRIPTION
Closes #42

## Summary

- `aitutor/tutor.go`: `ModelClaudeSonnet4_5` → `ModelClaudeHaiku4_5`

Haiku 4.5 is the cheapest Anthropic model ($1/1M input, $5/1M output vs Sonnet's $3/$15) and is well-suited for Go tutor Q&A.

---
_Generated by [Claude Code](https://claude.ai/code/session_012g3edjKRKYuy1PBNLfov96)_