### PR TITLE
fix: resolve lint findings from CI gate

### DIFF
--- a/aitutor/secrets.go
+++ b/aitutor/secrets.go
@@ -36,7 +36,7 @@ func readSecret(ctx context.Context, project string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("secretmanager client: %w", err)
 	}
-	defer client.Close()
+	defer func() { _ = client.Close() }()
 
 	name := fmt.Sprintf("projects/%s/secrets/%s/versions/latest", project, secretName)
 	result, err := client.AccessSecretVersion(ctx, &secretmanagerpb.AccessSecretVersionRequest{Name: name})

--- a/chapter1/livecaption/livecaption.go
+++ b/chapter1/livecaption/livecaption.go
@@ -7,6 +7,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -116,7 +117,7 @@ func sendStreamToGCP(w io.Writer, r io.Reader, s speechpb.Speech_StreamingRecogn
 		n, err := r.Read(buf) // Blocks on read until read.
 
 		secs := time.Since(timeStart).Seconds()
-		if err == io.EOF || secs > audioSpeakingTimeSec { // No more input
+		if errors.Is(err, io.EOF) || secs > audioSpeakingTimeSec { // No more input
 			ok := s.CloseSend()
 			if ok != nil {
 				_, _ = fmt.Fprintf(w, "Stream not closed: %s\n", ok)
@@ -149,7 +150,7 @@ func recvStreamFromGCP(w io.Writer, s speechpb.Speech_StreamingRecognizeClient,
 	defer wg.Done()
 	for {
 		resp, err := s.Recv()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 		if err != nil {

--- a/clients/df/newClient.go
+++ b/clients/df/newClient.go
@@ -32,7 +32,7 @@ func New(logger *log.Logger, gcpProject string, lang string) Bot {
 	}
 
 	ctx := context.Background() // Get a top level context
-	client, err := dialogflow.NewSessionsClient(ctx, option.WithCredentialsFile(gcpAuthFile))
+	client, err := dialogflow.NewSessionsClient(ctx, option.WithAuthCredentialsFile(option.ServiceAccount, gcpAuthFile))
 	if err != nil {
 		logger.Printf("Project %s, %s\n", gcpProject, err.Error())
 		return nil


### PR DESCRIPTION
Closes #46, closes #47, closes #48

## Summary

- `aitutor/secrets.go` — check `client.Close()` error return (errcheck)
- `chapter1/livecaption/livecaption.go` — `errors.Is(err, io.EOF)` instead of `==` in two places (errorlint)
- `clients/df/newClient.go` — replace deprecated `option.WithCredentialsFile` with `option.WithAuthCredentialsFile(option.ServiceAccount, ...)` (staticcheck SA1019); note `option.WithCredentialsJSON` is also deprecated in the current `google.golang.org/api` version, so `WithAuthCredentialsFile` is the current recommended replacement.

## Verification

- `go build ./...` — clean
- `gofmt -l .` — clean
- `go vet ./...` — clean
- `golangci-lint run` (full, unscoped) — **0 issues** (previously 4)
- `go test ./aitutor/... ./chapter1/livecaption/... ./clients/df/...` — pass

---
_Generated by [Claude Code](https://claude.ai/code/session_012g3edjKRKYuy1PBNLfov96)_