### PR TITLE
fix: resolve SA4005 in chapter1/structs instead of suppressing with nolint

### DIFF
--- a/chapter1/structs/structs.go
+++ b/chapter1/structs/structs.go
@@ -55,25 +55,22 @@ func (ath ThakurCopy) ValueDescribe() {
 	fmt.Printf("Value describe Thakur: %s: %d\n", ath.Name, ath.Age)
 }
 
-// ThoughtIGotMarried does not change the original. Ignore the [lint warning].
-//
-// [lint warning]: https://golangci-lint.run/usage/false-positives/
-//
-//nolint:staticcheck
+// ThoughtIGotMarried mutates only the local copy the value receiver got;
+// the caller's original ThakurCopy is untouched. Printing the copy here
+// makes that assignment observable instead of a dead store.
 func (ath ThakurCopy) ThoughtIGotMarried() {
 	ath.Name = "Mrs. " + ath.Name
+	fmt.Printf("ThoughtIGotMarried (local copy only): %s\n", ath.Name)
 }
 
-// GotMarried adds a Mrs in beginning, it is ineffective, ignore the lint warning.
-//
-//nolint:staticcheck
+// GotMarried mutates only the local copy; see ThoughtIGotMarried.
 func (ath ThakurCopy) GotMarried() {
 	ath.Name = "Mrs. " + ath.Name
+	fmt.Printf("GotMarried (local copy only): %s\n", ath.Name)
 }
 
-// ChangeToHeadOfHousehold changes the name and age
-//
-//nolint:staticcheck
+// ChangeToHeadOfHousehold mutates only the local copy; see ThoughtIGotMarried.
 func (ath ThakurCopy) ChangeToHeadOfHousehold() {
 	ath.Name, ath.Age = "Sofia", 40
+	fmt.Printf("ChangeToHeadOfHousehold (local copy only): %s: %d\n", ath.Name, ath.Age)
 }


### PR DESCRIPTION
## Problem

`chapter1/structs/structs.go` had three `//nolint:staticcheck` suppressions on value-receiver methods (`ThoughtIGotMarried`, `GotMarried`, `ChangeToHeadOfHousehold` on `ThakurCopy`) that mutate a field of the copy but never observe it, triggering `SA4005: ineffective assignment to field`.

## Fix

Instead of suppressing, each method now prints the copy's field right after the mutation. This makes the assignment observable (resolving SA4005 for real) and actually strengthens the book's teaching point — you can see the copy change while the original stays untouched.

## Verification

- `go build ./...` — clean
- `gofmt -l .` — clean
- `go vet ./...` — clean
- `golangci-lint run` (full, unscoped) — 0 issues
- `go test ./chapter1/structs/...` — pass
- `grep -rn "//nolint" .` — no matches remaining anywhere in the repo

---
_Generated by [Claude Code](https://claude.ai/code/session_012g3edjKRKYuy1PBNLfov96)_