### PR TITLE
docs: document ANTHROPIC_API_KEY and GOOGLE_CLOUD_PROJECT for the AI tutor

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,16 @@ $ ffmpeg -f avfoundation -i ":1" -acodec pcm_s16le -ar 48000 -f s16le udp://loca
 $ the-gpl stt --port=9999 # Will listen to RTP stream on port 9999 for 2 minutes and transcribe in real time
 ```
 
+### AI Tutor (Claude)
+The `tutor` CLI command and the `/ask` web endpoint are powered by Claude. Set:
+1. **ANTHROPIC_API_KEY** shell variable — required either way; used directly for local development, or as the fallback if Secret Manager is unavailable.
+2. **GOOGLE_CLOUD_PROJECT** shell variable — when set, `ANTHROPIC_API_KEY` is instead read from Google Cloud Secret Manager (`projects/{project}/secrets/ANTHROPIC_API_KEY/versions/latest`). This is set automatically on Cloud Run; set it manually to test Secret Manager locally.
+
+```shell script
+$ the-gpl tutor --q="What is a goroutine?"
+$ the-gpl tutor --chapter=5 --q="How does HTML traversal work?"
+```
+
 ### Simple Examples from book
 Use these commands to run utilities:
 1. bits: That counts number of 1 bits in a Hex input 


### PR DESCRIPTION
Closes #52

## Summary

- **README.md** — adds an "AI Tutor (Claude)" subsection documenting `ANTHROPIC_API_KEY` and `GOOGLE_CLOUD_PROJECT`, alongside the existing `GOOGLE_APPLICATION_CREDENTIALS` docs for the Dialogflow bot.

Confirmed via `grep -rn "os.Getenv" --include="*.go" .` that these three env vars are the only ones read anywhere in the codebase — nothing else needed documenting.

## #53 (.dockerignore `*.md`) — no code change, closed as not-planned

Investigated whether `.dockerignore`'s `*.md` pattern excludes `aitutor/prompt.md` (which `aitutor/tutor.go` needs via `//go:embed prompt.md`). Verified empirically with `github.com/moby/patternmatcher` — the actual library Docker/BuildKit uses to filter build context:

```
patterns: [*.md]
  README.md                 ignored=true
  aitutor/prompt.md         ignored=false
  chapter4/README.md        ignored=false
```

Docker's dockerignore matching diverges from `.gitignore` here: a bare pattern with no `/` compiles to `^[^/]*\.md$` — a single `*` never crosses a `/` (only `**` does), so it only ever matches root-level files. `aitutor/prompt.md` was never at risk. No `.dockerignore` change needed — see comment on #53 for full detail, closed as not-planned.

## Verification

- `go build ./...` — clean
- `gofmt -l .` — clean
- `go vet ./...` — clean
- README-only change, no code touched

---
_Generated by [Claude Code](https://claude.ai/code/session_012g3edjKRKYuy1PBNLfov96)_