### PR TITLE
refactor: route chapter1/bot's Dialogflow calls through clients.Gateway

### DIFF
--- a/chapter1/bot/chat.go
+++ b/chapter1/bot/chat.go
@@ -5,17 +5,18 @@ import (
 	"log"
 	"os"
 
+	"github.com/opendroid/the-gpl/clients"
 	"github.com/opendroid/the-gpl/clients/df"
 )
 
 var (
-	bot    df.Bot // bot to communicate with
-	logger = log.New(os.Stdout, "BOT ", log.LstdFlags)
+	gateway clients.Gateway // gateway to communicate with Dialogflow
+	logger  = log.New(os.Stdout, "BOT ", log.LstdFlags)
 )
 
 func chatWithBot(scan *bufio.Scanner, l *log.Logger, env df.Environment, gcpProjectID string, isChat bool) {
 	l.Printf("ExecCmd: bot %s. Say:\n", gcpProjectID)
-	if bot == nil {
+	if gateway.DialogFlowES == nil {
 		l.Printf("ExecCmd: Bot Error Creating DF session.")
 		return
 	}
@@ -23,7 +24,7 @@ func chatWithBot(scan *bufio.Scanner, l *log.Logger, env df.Environment, gcpProj
 	// Read from std input or use existing text
 	for scan.Scan() { // Scan line by line.
 		q := scan.Text()
-		r, err := bot.Converse(s, q)
+		r, err := gateway.Converse(s, q)
 		l.Printf("ExecCmd: chat %t, q: %s", isChat, q)
 		if err != nil {
 			l.Printf("ExecCmd: Conversation Error %s\n", err.Error())

--- a/chapter1/bot/cli.go
+++ b/chapter1/bot/cli.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/opendroid/the-gpl/clients"
 	"github.com/opendroid/the-gpl/clients/df"
 	"github.com/spf13/cobra"
 )
@@ -28,7 +29,7 @@ func NewBotCmd() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			fmt.Printf("chat: %t, project: %s\n", chat, gcpProjectName)
 			if gcpProjectName != "unit-test" {
-				bot = df.New(logger, gcpProjectName, lang)
+				gateway = clients.NewGateway(df.New(logger, gcpProjectName, lang), nil)
 			}
 			scan := bufio.NewScanner(strings.NewReader(df.SampleConvo))
 			if chat {

--- a/chapter1/bot/cli_test.go
+++ b/chapter1/bot/cli_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 
+	"github.com/opendroid/the-gpl/clients"
 	"github.com/opendroid/the-gpl/clients/df"
 	"github.com/stretchr/testify/assert"
 )
@@ -40,15 +41,15 @@ var agentResponses = []string{"cochatbot.hi_hcihy"}
 func TestCLI_ExecCmd(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
-	oldBot := bot
+	oldGateway := gateway
 	logger = log.New(&bytes.Buffer{}, "BOT ", log.LstdFlags)
-	defer func() { bot = oldBot }() // Restore bot
+	defer func() { gateway = oldGateway }() // Restore gateway
 	mockBot := dfMock.NewMockBot(mockCtrl)
 	first := mockBot.EXPECT().Converse(gomock.Any(), "hello").Return(agentResponses, nil).Times(1)
 	second := mockBot.EXPECT().Converse(gomock.Any(), "i like to cancel").Return(agentResponses, nil).Times(1)
 	third := mockBot.EXPECT().Converse(gomock.Any(), "taking too long").Return(agentResponses, nil).Times(1)
 	gomock.InOrder(first, second, third)
-	bot = mockBot
+	gateway = clients.NewGateway(mockBot, nil)
 
 	cmd := NewBotCmd()
 	cmd.SetArgs([]string{"--chat=false", "--project=unit-test"})
@@ -58,7 +59,7 @@ func TestCLI_ExecCmd(t *testing.T) {
 
 // TestCLI_ExecCmd_BotNil tests the chatting with the bot when bot is nil.
 func TestCLI_ExecCmd_BotNil(t *testing.T) {
-	bot = nil
+	gateway = clients.Gateway{}
 	logger = log.New(&bytes.Buffer{}, "BOT ", log.LstdFlags)
 
 	cmd := NewBotCmd()
@@ -71,12 +72,12 @@ func TestCLI_ExecCmd_BotNil(t *testing.T) {
 func TestCLI_ExecCmd_ConverseError(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
-	oldBot := bot
+	oldGateway := gateway
 	logger = log.New(&bytes.Buffer{}, "BOT ", log.LstdFlags)
-	defer func() { bot = oldBot }() // Restore bot
+	defer func() { gateway = oldGateway }() // Restore gateway
 	mockBot := dfMock.NewMockBot(mockCtrl)
 	mockBot.EXPECT().Converse(gomock.Any(), "hello").Return(nil, fmt.Errorf("mock Error.")).Times(1)
-	bot = mockBot
+	gateway = clients.NewGateway(mockBot, nil)
 
 	cmd := NewBotCmd()
 	cmd.SetArgs([]string{"--chat=false", "--project=unit-test"})

--- a/clients/gateway.go
+++ b/clients/gateway.go
@@ -33,3 +33,8 @@ func (g Gateway) Ask(question, chapterContext string) (string, error) {
 	}
 	return g.Anthropic.Ask(context.Background(), systemPrompt, userContent)
 }
+
+// Converse sends a message to the Gateway's Dialogflow client and returns the agent's responses.
+func (g Gateway) Converse(s *df.AgentSession, q string) ([]string, error) {
+	return g.DialogFlowES.Converse(s, q)
+}


### PR DESCRIPTION
Closes #57

## Summary

`clients.Gateway` (from #55/#56) already had a `DialogFlowES df.Bot` field, but nothing populated or called through it — `chapter1/bot` still talked to a package-level `var bot df.Bot` directly, the one remaining inconsistency with the pattern established for the Anthropic client (`aitutor`, `serve/web` both go through a package-level `clients.Gateway`).

- `clients/gateway.go` — new `Converse(s *df.AgentSession, q string) ([]string, error)` method, delegating to `g.DialogFlowES`, mirroring `Ask`'s delegation to `g.Anthropic`.
- `chapter1/bot/chat.go` — replaces `var bot df.Bot` with `var gateway clients.Gateway`; `chatWithBot` now calls `gateway.Converse(s, q)` instead of `bot.Converse(s, q)`.
- `chapter1/bot/cli.go` — builds `gateway = clients.NewGateway(df.New(...), nil)` instead of assigning `bot` directly.
- `chapter1/bot/cli_test.go` — the three existing tests now inject/reset the mock via `gateway` instead of the removed `bot` var (same mock, same assertions, same coverage).

No behavior change — same CLI flags, same conversation flow.

## Verification

- `go build ./...` — clean
- `gofmt -l .` — clean
- `go vet ./...` — clean
- `golangci-lint run` (full, unscoped) — 0 issues
- `go test ./chapter1/bot/... ./clients/...` — all pass (`TestNewBotCmd`, `TestCLI_ExecCmd`, `TestCLI_ExecCmd_BotNil`, `TestCLI_ExecCmd_ConverseError`, plus the existing `clients`/`clients/df` tests)

---
_Generated by [Claude Code](https://claude.ai/code/session_012g3edjKRKYuy1PBNLfov96)_