### PR TITLE
Redesign web UI: light minimal theme + Home & Demos pages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,8 @@ the-gpl server --port=8080   # start web server
 ## Architecture
 
 - **Single binary**: `main.go` wires cobra commands from all chapters + the web server.
-- **Web server** (`serve/web/`): `Start()` in `web.go` registers all `http.HandleFunc` entries defined in `handlers` map; templates are in `webtpl.go`; page-data types in `pagedata.go`.
+- **Web server** (`serve/web/`): `Start()` in `web.go` registers all `http.HandleFunc` entries defined in `handlers` map; templates are in `webtpl.go`; page-data types in `pagedata.go`; home/demos static data in `demodata.go`.
+- **Theme**: `public/css/redesign/` is the live theme (light, JetBrains Mono + Helvetica), linked from `head.gohtml`. `public/css/initial/` is the previous dark theme, kept for rollback — switch back by pointing the `head.gohtml` links at `initial/`.
 - **Cloud Run**: deployed as a single container (`Dockerfile`, `cloudbuild.yaml`) with one instance — no shared state concerns between replicas.
 - **External APIs**: Dialogflow and Speech-to-Text require `GOOGLE_APPLICATION_CREDENTIALS` to point to a GCP service-account JSON file. Never commit credentials.
 

--- a/public/css/redesign/about.css
+++ b/public/css/redesign/about.css
@@ -1,0 +1,32 @@
+/* the-gpl redesign — /about. */
+
+.about-section { padding-top: clamp(40px, 6vw, 72px); padding-bottom: clamp(40px, 6vw, 72px); }
+.about-lede { margin-top: 16px; margin-bottom: 40px; max-width: 56ch; }
+
+.social-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+    gap: 16px;
+}
+.social-card {
+    display: flex;
+    flex-direction: column;
+    background: var(--panel);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-xl);
+    overflow: hidden;
+    color: inherit;
+}
+.social-card:hover { color: inherit; border-color: var(--accent); }
+.social-card-cover { height: 150px; overflow: hidden; background: var(--hairline); }
+.social-card-cover img { width: 100%; height: 100%; object-fit: cover; display: block; }
+.social-card-body {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 16px 18px;
+}
+.social-card-meta { display: flex; flex-direction: column; gap: 3px; }
+.social-card-platform { font-family: var(--mono); font-size: 12px; color: var(--faint); }
+.social-card-handle { font-size: 17px; font-weight: 600; color: var(--ink); }
+.social-card-arrow { font-family: var(--mono); color: var(--accent); font-size: 15px; }

--- a/public/css/redesign/chapters.css
+++ b/public/css/redesign/chapters.css
@@ -1,0 +1,28 @@
+/* the-gpl redesign — /chapters. */
+
+.chapters-section { padding-top: clamp(40px, 6vw, 72px); padding-bottom: clamp(40px, 6vw, 72px); }
+.chapters-lede { margin-top: 16px; margin-bottom: 40px; }
+
+.chapters-list { display: grid; gap: 12px; }
+.chapter-card {
+    background: var(--panel);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    padding: 22px 24px;
+    display: flex;
+    gap: 22px;
+    align-items: flex-start;
+    color: inherit;
+}
+.chapter-card:hover { color: inherit; border-color: var(--accent); }
+.chapter-no {
+    font-family: var(--mono);
+    font-size: 15px;
+    font-weight: 700;
+    color: var(--accent);
+    min-width: 38px;
+    padding-top: 2px;
+}
+.chapter-body { flex: 1; }
+.chapter-title { font-size: 19px; font-weight: 600; letter-spacing: -0.01em; }
+.chapter-desc { margin-top: 8px; font-size: 14px; color: var(--muted); line-height: 1.5; }

--- a/public/css/redesign/demos.css
+++ b/public/css/redesign/demos.css
@@ -16,14 +16,7 @@
 
 /* ---- demo detail ---- */
 .demo-detail { padding-top: clamp(28px, 5vw, 56px); padding-bottom: clamp(28px, 5vw, 56px); }
-.demo-back {
-    display: inline-block;
-    font-family: var(--mono);
-    font-size: 13px;
-    color: var(--muted);
-    margin-bottom: 22px;
-}
-.demo-back:hover { color: var(--accent); }
+/* .demo-back is shared (main.css) — also used on the Post Data page */
 .demo-detail-head {
     display: flex;
     align-items: center;

--- a/public/css/redesign/demos.css
+++ b/public/css/redesign/demos.css
@@ -1,0 +1,109 @@
+/* the-gpl redesign — /demos gallery + demo-detail (lissajous/mandelbrot/surfaces). */
+
+.demos-section { padding-top: clamp(40px, 6vw, 72px); padding-bottom: clamp(40px, 6vw, 72px); }
+.demos-lede { margin-top: 16px; margin-bottom: 40px; }
+
+/* gallery: slightly larger cards than the home strip */
+.demo-grid-gallery {
+    grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+    gap: 18px;
+}
+.demo-grid-gallery .demo-card { border-radius: var(--radius-xl); }
+.demo-grid-gallery .demo-card-preview { height: 160px; }
+.demo-grid-gallery .demo-card-body { padding: 18px; }
+.demo-grid-gallery .demo-card-name { font-size: 17px; }
+.demo-grid-gallery .demo-card-short { margin-top: 8px; line-height: 1.5; }
+
+/* ---- demo detail ---- */
+.demo-detail { padding-top: clamp(28px, 5vw, 56px); padding-bottom: clamp(28px, 5vw, 56px); }
+.demo-back {
+    display: inline-block;
+    font-family: var(--mono);
+    font-size: 13px;
+    color: var(--muted);
+    margin-bottom: 22px;
+}
+.demo-back:hover { color: var(--accent); }
+.demo-detail-head {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-wrap: wrap;
+}
+.demo-detail-tag {
+    font-family: var(--mono);
+    font-size: 11px;
+    color: var(--accent);
+    background: var(--accent-tint);
+    border-radius: var(--radius-sm);
+    padding: 4px 9px;
+}
+.demo-detail-desc { margin: 16px 0 28px; max-width: 60ch; line-height: 1.55; }
+
+.demo-output {
+    background: var(--panel);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-xl);
+    overflow: hidden;
+}
+.demo-output-preview {
+    position: relative;
+    height: clamp(220px, 40vw, 360px);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    border-bottom: 1px solid var(--border);
+    overflow: hidden;
+}
+.demo-output-img {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+    background: var(--panel);
+    display: block;
+}
+.demo-output-badge {
+    position: relative;
+    z-index: 1;
+    font-family: var(--mono);
+    font-size: 12px;
+    color: var(--faint);
+    background: var(--panel);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    padding: 3px 8px;
+}
+.demo-output-format {
+    position: relative;
+    z-index: 1;
+    font-family: var(--mono);
+    font-size: 11px;
+    color: var(--faint);
+}
+.demo-params { padding: 22px 24px; }
+.demo-params-label {
+    font-family: var(--mono);
+    font-size: 12px;
+    color: var(--faint);
+    margin-bottom: 14px;
+}
+.demo-params-list { display: grid; gap: 10px; }
+.demo-param {
+    display: flex;
+    gap: 14px;
+    align-items: baseline;
+    padding-bottom: 10px;
+    border-bottom: 1px solid var(--hairline);
+}
+.demo-param-name {
+    font-family: var(--mono);
+    font-size: 13px;
+    color: var(--accent);
+    min-width: 96px;
+}
+.demo-param-note { font-size: 14px; color: var(--muted); }
+.demo-run { margin-top: 22px; }

--- a/public/css/redesign/footer.css
+++ b/public/css/redesign/footer.css
@@ -1,0 +1,59 @@
+/* the-gpl redesign — footer: MLK quote + BLM + book/tools columns + bottom strip. */
+
+.site-footer {
+    flex-shrink: 0;
+    border-top: 1px solid var(--border);
+    background: var(--footer-bg);
+}
+.site-footer-inner {
+    max-width: 1120px;
+    margin: 0 auto;
+    padding: 40px 24px;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 28px;
+    justify-content: space-between;
+}
+
+.footer-quote { max-width: 44ch; }
+.footer-quote blockquote {
+    margin: 0;
+    font-size: 16px;
+    line-height: 1.55;
+    color: var(--ink);
+}
+.footer-quote-attr {
+    font-size: 13px;
+    color: var(--muted);
+    margin-top: 8px;
+}
+.footer-blm {
+    font-family: var(--mono);
+    font-size: 12px;
+    color: var(--accent);
+    margin-top: 16px;
+}
+
+.footer-cols { display: flex; gap: 36px; flex-wrap: wrap; }
+.footer-col { display: flex; flex-direction: column; gap: 8px; }
+.footer-col-head {
+    font-family: var(--mono);
+    font-size: 12px;
+    color: var(--faint);
+    margin-bottom: 2px;
+}
+.footer-col a {
+    font-size: 14px;
+    color: var(--ink);
+}
+.footer-col a:hover { color: var(--accent); }
+
+.footer-strip { border-top: 1px solid var(--border); }
+.footer-strip-inner {
+    max-width: 1120px;
+    margin: 0 auto;
+    padding: 16px 24px;
+    font-family: var(--mono);
+    font-size: 12px;
+    color: var(--faint);
+}

--- a/public/css/redesign/home.css
+++ b/public/css/redesign/home.css
@@ -1,0 +1,36 @@
+/* the-gpl redesign — landing page. */
+
+.home-hero { padding-top: clamp(48px, 9vw, 104px); padding-bottom: clamp(36px, 6vw, 64px); }
+.hero-title { max-width: 16ch; margin: 0; text-wrap: balance; }
+.accent-ink { color: var(--accent); }
+.home-hero-lede { margin-top: 24px; font-size: clamp(16px, 2vw, 20px); max-width: 56ch; }
+.home-hero-actions { display: flex; flex-wrap: wrap; gap: 12px; margin-top: 36px; }
+
+.home-stats-section { padding-top: 8px; padding-bottom: 24px; }
+.home-stats {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 16px;
+}
+.stat { padding: 22px; }
+.stat-num {
+    font-family: var(--mono);
+    font-size: 32px;
+    font-weight: 700;
+    color: var(--ink);
+    letter-spacing: -0.02em;
+}
+.stat-label { font-size: 14px; color: var(--muted); margin-top: 6px; }
+
+.home-demos-section { padding-top: clamp(32px, 5vw, 56px); padding-bottom: clamp(32px, 5vw, 56px); }
+.home-demos-head {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 12px;
+    margin-bottom: 22px;
+}
+.home-demos-viewall { font-family: var(--mono); font-size: 13px; color: var(--accent); }
+
+.demo-grid-home { grid-template-columns: repeat(auto-fill, minmax(230px, 1fr)); }

--- a/public/css/redesign/main.css
+++ b/public/css/redesign/main.css
@@ -95,6 +95,16 @@ p { margin: 0; line-height: 1.5; }
     line-height: 1.5;
 }
 
+/* back link to the demos gallery (demo detail + post data pages) */
+.demo-back {
+    display: inline-block;
+    font-family: var(--mono);
+    font-size: 13px;
+    color: var(--muted);
+    margin-bottom: 22px;
+}
+.demo-back:hover { color: var(--accent); }
+
 /* buttons / links styled as buttons */
 .btn {
     display: inline-block;

--- a/public/css/redesign/main.css
+++ b/public/css/redesign/main.css
@@ -1,0 +1,209 @@
+/* the-gpl redesign — design tokens + shared components.
+   Light, minimal theme. No shadows. See public/css/initial/ for the old theme. */
+
+:root {
+    --bg: #f7f6f3;
+    --panel: #ffffff;
+    --panel-alt: #fbfaf8;
+    --footer-bg: #f2f1ec;
+    --ink: #1a1c22;
+    --muted: #6b6f76;
+    --faint: #9a9ea3;
+    --border: #e6e4de;
+    --border-input: #d9d7d0;
+    --hairline: #f0efea;
+    --accent: #0d8a86;
+    --accent-hover: #0a6d6a;
+    --accent-tint: #eaf4f3;
+
+    /* dark code panel */
+    --code-bg: #14161b;
+    --code-key: #5fb8b4;
+    --code-sep: #5c6069;
+    --code-val: #c9ccd1;
+
+    --radius-sm: 7px;
+    --radius-md: 10px;
+    --radius-lg: 14px;
+    --radius-xl: 16px;
+
+    --mono: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+    --ui: "Helvetica Neue", Helvetica, Arial, sans-serif;
+
+    --stripes: repeating-linear-gradient(135deg, #f0efea 0 10px, #f7f6f3 10px 20px);
+}
+
+/* ---- reset ---- */
+* { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; }
+html { border: 0; }
+body {
+    background: var(--bg);
+    color: var(--ink);
+    font-family: var(--ui);
+    -webkit-font-smoothing: antialiased;
+    text-rendering: optimizeLegibility;
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+}
+img { max-width: 100%; }
+a { color: var(--accent); text-decoration: none; }
+a:hover { color: var(--accent-hover); }
+::selection { background: var(--accent); color: #fff; }
+
+/* main fills between sticky header and footer */
+main[role="main"] { flex: 1 0 auto; width: 100%; }
+
+/* ---- headings / type scale ---- */
+h1, h2, h3, h4 {
+    color: var(--ink);
+    margin: 0;
+    letter-spacing: -0.02em;
+    font-weight: 700;
+}
+h1 { font-size: clamp(30px, 5vw, 52px); letter-spacing: -0.03em; }
+h2 { font-size: clamp(22px, 3vw, 30px); }
+.hero-title { font-size: clamp(34px, 6vw, 68px); line-height: 1.02; letter-spacing: -0.03em; }
+p { margin: 0; line-height: 1.5; }
+
+/* ---- layout ---- */
+.container { max-width: 1120px; margin: 0 auto; padding: 0 24px; width: 100%; }
+.container-960 { max-width: 960px; margin: 0 auto; padding: 0 24px; width: 100%; }
+.container-900 { max-width: 900px; margin: 0 auto; padding: 0 24px; width: 100%; }
+.container-820 { max-width: 820px; margin: 0 auto; padding: 0 24px; width: 100%; }
+
+.section { padding: clamp(40px, 6vw, 72px) 24px; }
+.fade-up { animation: fadeUp 0.4s ease both; }
+@keyframes fadeUp {
+    from { opacity: 0; transform: translateY(8px); }
+    to   { opacity: 1; transform: translateY(0); }
+}
+
+/* ---- shared components ---- */
+.kicker {
+    font-family: var(--mono);
+    font-size: 13px;
+    color: var(--accent);
+    letter-spacing: 0.02em;
+    margin-bottom: 14px;
+}
+.lede {
+    font-size: 17px;
+    color: var(--muted);
+    max-width: 60ch;
+    line-height: 1.5;
+}
+
+/* buttons / links styled as buttons */
+.btn {
+    display: inline-block;
+    cursor: pointer;
+    border: none;
+    border-radius: var(--radius-md);
+    padding: 13px 22px;
+    font-family: var(--ui);
+    font-size: 15px;
+    font-weight: 500;
+    line-height: 1.2;
+    transition: background 0.15s, color 0.15s;
+}
+.btn-dark   { background: var(--ink); color: #fff; }
+.btn-dark:hover { color: #fff; background: #2a2d35; }
+.btn-light  { background: var(--panel); color: var(--ink); border: 1px solid var(--border-input); }
+.btn-light:hover { color: var(--ink); background: var(--panel-alt); }
+.btn-accent { background: var(--accent); color: #fff; }
+.btn-accent:hover { background: var(--accent-hover); color: #fff; }
+
+/* chip / pill */
+.chip {
+    display: inline-block;
+    font-family: var(--mono);
+    font-size: 12px;
+    color: var(--muted);
+    background: var(--hairline);
+    border-radius: 20px;
+    padding: 6px 12px;
+    border: none;
+    cursor: pointer;
+}
+.chip:hover { color: var(--ink); }
+
+/* badges */
+.badge {
+    font-family: var(--mono);
+    font-size: 11px;
+    border-radius: var(--radius-sm);
+    padding: 3px 8px;
+}
+.badge-route { color: var(--faint); background: var(--panel); border: 1px solid var(--border); }
+.badge-tag   { color: var(--accent); background: var(--accent-tint); }
+
+/* cards */
+.card {
+    background: var(--panel);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+}
+
+/* dark code panel (headers dump) */
+.code-panel {
+    background: var(--code-bg);
+    border-radius: var(--radius-lg);
+    padding: 20px 22px;
+    overflow-x: auto;
+    font-family: var(--mono);
+    font-size: 13px;
+    line-height: 1.9;
+    color: var(--code-val);
+}
+.code-panel .k { color: var(--code-key); }
+.code-panel .sep { color: var(--code-sep); }
+.code-panel .v { color: var(--code-val); }
+
+/* striped placeholder */
+.stripes { background-image: var(--stripes); }
+
+/* ---- demo cards (home strip + /demos gallery) ---- */
+.demo-grid { display: grid; gap: 16px; }
+.demo-card {
+    text-align: left;
+    background: var(--panel);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    color: inherit;
+}
+.demo-card:hover { color: inherit; border-color: var(--accent); }
+.demo-card-preview {
+    position: relative;
+    height: 130px;
+    border-bottom: 1px solid var(--border);
+    display: flex;
+    align-items: flex-end;
+    justify-content: flex-end;
+    padding: 12px;
+    overflow: hidden;
+}
+.demo-card-preview-center { align-items: center; justify-content: center; }
+.demo-card-img {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+}
+.demo-card-badge { position: relative; z-index: 1; }
+.demo-card-plain { font-family: var(--mono); font-size: 12px; color: var(--faint); }
+.demo-card-body { padding: 16px; }
+.demo-card-body-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+}
+.demo-card-name { font-size: 16px; font-weight: 600; color: var(--ink); }
+.demo-card-short { font-size: 13px; color: var(--muted); margin-top: 5px; line-height: 1.45; }

--- a/public/css/redesign/nav.css
+++ b/public/css/redesign/nav.css
@@ -1,0 +1,112 @@
+/* the-gpl redesign — sticky blurred header + wordmark + nav pills. */
+
+.site-header {
+    position: sticky;
+    top: 0;
+    z-index: 50;
+    background: rgba(247, 246, 243, 0.86);
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
+    border-bottom: 1px solid var(--border);
+}
+.site-header-inner {
+    max-width: 1120px;
+    margin: 0 auto;
+    padding: 0 24px;
+    height: 64px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+}
+
+/* wordmark */
+.wordmark {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+.wordmark:hover { color: inherit; }
+.wordmark-glyph {
+    width: 26px;
+    height: 26px;
+    border-radius: var(--radius-sm);
+    background: var(--accent);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #fff;
+    font-family: var(--mono);
+    font-weight: 700;
+    font-size: 14px;
+}
+.wordmark-text {
+    font-family: var(--mono);
+    font-weight: 500;
+    font-size: 15px;
+    letter-spacing: -0.01em;
+    color: var(--ink);
+}
+
+/* desktop nav */
+.site-nav { display: flex; align-items: center; gap: 4px; }
+.nav-pill {
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    padding: 8px 14px;
+    border-radius: 8px;
+    font-family: var(--ui);
+    font-size: 14px;
+    font-weight: 500;
+    color: #4a4e55;
+    transition: background 0.15s, color 0.15s;
+}
+.nav-pill:hover { color: var(--ink); }
+.nav-pill.active { background: var(--accent-tint); color: var(--accent-hover); }
+
+/* hamburger — hidden on desktop */
+.nav-toggle {
+    display: none;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    gap: 5px;
+    width: 42px;
+    height: 42px;
+    background: var(--panel);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
+    cursor: pointer;
+}
+.nav-toggle span {
+    display: block;
+    width: 18px;
+    height: 2px;
+    background: var(--ink);
+    border-radius: 2px;
+}
+
+/* mobile sheet — hidden by default */
+.nav-sheet {
+    display: none;
+    border-top: 1px solid var(--border);
+    background: var(--bg);
+    padding: 8px 16px 16px;
+}
+.nav-sheet .nav-pill {
+    display: block;
+    width: 100%;
+    text-align: left;
+    border-radius: 0;
+    border-bottom: 1px solid #ecebe6;
+    padding: 14px 8px;
+    font-size: 16px;
+}
+.nav-sheet .nav-pill:last-child { border-bottom: none; }
+
+@media (max-width: 760px) {
+    .site-nav { display: none; }
+    .nav-toggle { display: flex; }
+    .nav-sheet.open { display: block; }
+}

--- a/public/css/redesign/post.css
+++ b/public/css/redesign/post.css
@@ -1,0 +1,35 @@
+/* the-gpl redesign — /post + /index request inspector. */
+
+.post-section { padding-top: clamp(40px, 6vw, 72px); padding-bottom: clamp(40px, 6vw, 72px); }
+.post-lede { margin-top: 16px; margin-bottom: 32px; max-width: 58ch; }
+
+.post-form {
+    background: var(--panel);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-xl);
+    padding: 24px;
+    display: grid;
+    gap: 16px;
+    max-width: 520px;
+}
+.post-field { display: grid; gap: 6px; }
+.post-field-label { font-family: var(--mono); font-size: 12px; color: var(--muted); }
+.post-input {
+    border: 1px solid var(--border-input);
+    border-radius: var(--radius-md);
+    padding: 12px 14px;
+    font-size: 15px;
+    font-family: var(--ui);
+    background: var(--panel-alt);
+    color: var(--ink);
+}
+.post-input:focus { outline: none; border-color: var(--accent); }
+.post-submit { justify-self: start; }
+
+.post-response { margin-top: 36px; }
+.post-response-label {
+    font-family: var(--mono);
+    font-size: 12px;
+    color: var(--faint);
+    margin-bottom: 12px;
+}

--- a/public/css/redesign/tutor.css
+++ b/public/css/redesign/tutor.css
@@ -2,14 +2,6 @@
 
 .tutor-section { padding-top: clamp(40px, 6vw, 72px); padding-bottom: clamp(40px, 6vw, 72px); }
 .tutor-lede { margin-top: 16px; margin-bottom: 32px; max-width: 56ch; }
-.tutor-lede code {
-    font-family: var(--mono);
-    font-size: 0.85em;
-    background: var(--hairline);
-    border-radius: 4px;
-    padding: 1px 5px;
-    color: var(--ink);
-}
 
 .chat-box {
     background: var(--panel);

--- a/public/css/redesign/tutor.css
+++ b/public/css/redesign/tutor.css
@@ -15,8 +15,8 @@
     background: var(--panel);
     border: 1px solid var(--border);
     border-radius: var(--radius-xl);
-    min-height: 200px;
-    max-height: 460px;
+    min-height: 380px;
+    max-height: 640px;
     overflow-y: auto;
     padding: 20px;
     margin-bottom: 16px;
@@ -65,7 +65,6 @@
     resize: vertical;
     background: var(--panel-alt);
     line-height: 1.6;
-    min-height: 240px;
     color: var(--ink);
 }
 .chat-form textarea:focus { outline: none; border-color: var(--accent); }

--- a/public/css/redesign/tutor.css
+++ b/public/css/redesign/tutor.css
@@ -1,0 +1,84 @@
+/* the-gpl redesign — /ask-page Go tutor. */
+
+.tutor-section { padding-top: clamp(40px, 6vw, 72px); padding-bottom: clamp(40px, 6vw, 72px); }
+.tutor-lede { margin-top: 16px; margin-bottom: 32px; max-width: 56ch; }
+.tutor-lede code {
+    font-family: var(--mono);
+    font-size: 0.85em;
+    background: var(--hairline);
+    border-radius: 4px;
+    padding: 1px 5px;
+    color: var(--ink);
+}
+
+.chat-box {
+    background: var(--panel);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-xl);
+    min-height: 200px;
+    max-height: 460px;
+    overflow-y: auto;
+    padding: 20px;
+    margin-bottom: 16px;
+    font-size: 15px;
+    line-height: 1.55;
+}
+.chat-msg { margin-bottom: 0.9rem; }
+.chat-msg.user  { color: var(--accent-hover); }
+.chat-msg.tutor { color: var(--ink); }
+.chat-box code {
+    background: var(--hairline);
+    padding: 1px 5px;
+    border-radius: 4px;
+    font-family: var(--mono);
+    font-size: 0.88em;
+}
+.chat-box pre {
+    background: var(--code-bg);
+    color: var(--code-val);
+    padding: 0.7rem 0.9rem;
+    border-radius: var(--radius-md);
+    overflow-x: auto;
+    margin: 0.5rem 0;
+}
+.chat-box pre code { background: none; padding: 0; color: inherit; }
+.chat-box h3, .chat-box h4, .chat-box h5 { color: var(--ink); margin: 0.6rem 0 0.3rem; }
+.chat-box table { border-collapse: collapse; margin: 0.6rem 0; font-size: 0.9rem; }
+.chat-box th, .chat-box td { border: 1px solid var(--border); padding: 5px 11px; text-align: left; }
+.chat-box th { background: var(--accent-tint); color: var(--ink); }
+.chat-box tr:nth-child(even) td { background: var(--panel-alt); }
+
+.chat-form {
+    background: var(--panel);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-xl);
+    padding: 22px;
+    display: grid;
+    gap: 14px;
+}
+.chat-form textarea {
+    border: 1px solid var(--border-input);
+    border-radius: var(--radius-lg);
+    padding: 16px;
+    font-size: 16px;
+    font-family: var(--ui);
+    resize: vertical;
+    background: var(--panel-alt);
+    line-height: 1.6;
+    min-height: 240px;
+    color: var(--ink);
+}
+.chat-form textarea:focus { outline: none; border-color: var(--accent); }
+.chat-chips { display: flex; flex-wrap: wrap; gap: 8px; }
+.chat-actions { display: flex; align-items: center; gap: 10px; }
+.chat-form select {
+    padding: 10px 12px;
+    border: 1px solid var(--border-input);
+    border-radius: var(--radius-md);
+    background: var(--panel);
+    color: var(--ink);
+    font-family: var(--ui);
+    font-size: 14px;
+}
+.chat-form select:focus { outline: none; border-color: var(--accent); }
+#sendBtn:disabled { background: var(--faint); cursor: not-allowed; }

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -22,7 +22,10 @@ Source: https://github.com/opendroid/the-gpl
 
 ## Web Routes (https://the-gpl.com)
 
-- [/index](https://the-gpl.com/index) — Home page
+- [/](https://the-gpl.com/) — Home / landing page (hero, stats, demos strip)
+- [/demos](https://the-gpl.com/demos) — Interactive demos gallery
+- [/post](https://the-gpl.com/post) — Request inspector (submit form fields, echoes the request)
+- [/index](https://the-gpl.com/index) — Request inspector (headers echo)
 - [/about](https://the-gpl.com/about) — About page
 - [/lis](https://the-gpl.com/lis) — Lissajous animated GIF
 - [/mandel](https://the-gpl.com/mandel) — Mandelbrot fractal (color)

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,39 +1,58 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-    <!--  created with Free Online Sitemap Generator www.xml-sitemaps.com  -->
     <url>
         <loc>https://the-gpl.com/</loc>
-        <lastmod>2020-12-30T19:46:18+00:00</lastmod>
+        <lastmod>2026-07-22T00:00:00+00:00</lastmod>
         <priority>1.00</priority>
     </url>
     <url>
+        <loc>https://the-gpl.com/chapters</loc>
+        <lastmod>2026-07-22T00:00:00+00:00</lastmod>
+        <priority>0.90</priority>
+    </url>
+    <url>
+        <loc>https://the-gpl.com/demos</loc>
+        <lastmod>2026-07-22T00:00:00+00:00</lastmod>
+        <priority>0.90</priority>
+    </url>
+    <url>
+        <loc>https://the-gpl.com/post</loc>
+        <lastmod>2026-07-22T00:00:00+00:00</lastmod>
+        <priority>0.70</priority>
+    </url>
+    <url>
         <loc>https://the-gpl.com/lis</loc>
-        <lastmod>2020-12-30T19:46:18+00:00</lastmod>
+        <lastmod>2026-07-22T00:00:00+00:00</lastmod>
         <priority>0.80</priority>
     </url>
     <url>
         <loc>https://the-gpl.com/sinc</loc>
-        <lastmod>2020-12-30T19:46:18+00:00</lastmod>
+        <lastmod>2026-07-22T00:00:00+00:00</lastmod>
         <priority>0.80</priority>
     </url>
     <url>
         <loc>https://the-gpl.com/egg</loc>
-        <lastmod>2020-12-30T19:46:18+00:00</lastmod>
+        <lastmod>2026-07-22T00:00:00+00:00</lastmod>
         <priority>0.80</priority>
     </url>
     <url>
         <loc>https://the-gpl.com/valley</loc>
-        <lastmod>2020-12-30T19:46:18+00:00</lastmod>
+        <lastmod>2026-07-22T00:00:00+00:00</lastmod>
         <priority>0.80</priority>
     </url>
     <url>
         <loc>https://the-gpl.com/sq</loc>
-        <lastmod>2020-12-30T19:46:18+00:00</lastmod>
+        <lastmod>2026-07-22T00:00:00+00:00</lastmod>
         <priority>0.80</priority>
     </url>
     <url>
+        <loc>https://the-gpl.com/ask-page</loc>
+        <lastmod>2026-07-22T00:00:00+00:00</lastmod>
+        <priority>0.70</priority>
+    </url>
+    <url>
         <loc>https://the-gpl.com/about</loc>
-        <lastmod>2020-12-30T19:46:18+00:00</lastmod>
+        <lastmod>2026-07-22T00:00:00+00:00</lastmod>
         <priority>0.80</priority>
     </url>
 </urlset>

--- a/public/templates/about.gohtml
+++ b/public/templates/about.gohtml
@@ -2,22 +2,20 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>About</title>
+    <title>About — The GPL</title>
     {{template "head"}}
-    <link rel="stylesheet" href="/public/css/initial/socialcard.css">
+    <link rel="stylesheet" href="/public/css/redesign/about.css">
 </head>
 <body>
-<!-- Horizontal navigation section: Fill in navigation template -->
 {{template "navflex" .Active}}
-
-<!-- Table for Header key/values -->
-<section class="about-connect-info-cards">
-    <h3> To connect use these channels:</h3>
-
-    <!-- Add social cards -->
-    {{template "socialcard" .Data}}
-</section>
-<!-- Footer quote -->
+<main role="main">
+    <section class="container-820 fade-up about-section">
+        <div class="kicker">// about</div>
+        <h1>Ajay Thakur</h1>
+        <p class="lede about-lede">Engineer working through <em>The Go Programming Language</em> in public. The source for every demo lives on GitHub &mdash; say hello on any of these.</p>
+        {{template "socialcard" .Data}}
+    </section>
+</main>
 {{template "footer"}}
 </body>
 </html>

--- a/public/templates/ask.gohtml
+++ b/public/templates/ask.gohtml
@@ -2,81 +2,53 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>Go Tutor — The GPL</title>
+    <title>Tutor — The GPL</title>
     {{template "head"}}
-    <link rel="stylesheet" href="/public/css/initial/indextable.css">
-    <style>
-        .chat-container { max-width: 720px; margin: 1.5rem auto; padding: 0 1rem; }
-        .chat-box {
-            border: 1px solid #555; border-radius: 6px;
-            min-height: 260px; max-height: 480px;
-            overflow-y: auto; padding: 1rem;
-            background: #2a2433; color: #e8e8e8; font-size: 0.95rem; margin-bottom: 1rem;
-        }
-        .chat-msg { margin-bottom: 0.8rem; }
-        .chat-msg.user  { color: #7ab3f7; }
-        .chat-msg.tutor { color: #e8e8e8; }
-        .chat-box code {
-            background: #1a1228; padding: 1px 4px;
-            border-radius: 3px; font-family: monospace;
-        }
-        .chat-box pre {
-            background: #1a1228; padding: 0.6rem;
-            border-radius: 4px; overflow-x: auto; margin: 0.4rem 0;
-        }
-        .chat-box pre code { background: none; padding: 0; }
-        .chat-box h3, .chat-box h4, .chat-box h5 {
-            color: #e8e8e8; margin: 0.5rem 0 0.2rem;
-        }
-        .chat-box table { border-collapse: collapse; margin: 0.5rem 0; font-size: 0.88rem; }
-        .chat-box th, .chat-box td { border: 1px solid #555; padding: 4px 10px; text-align: left; }
-        .chat-box th { background: #3a3250; color: #e8e8e8; }
-        .chat-box tr:nth-child(even) td { background: #251e32; }
-        .chat-form { display: flex; gap: 0.5rem; }
-        .chat-form input[type=text] {
-            flex: 1; padding: 0.5rem 0.7rem;
-            border: 1px solid #666; border-radius: 4px; font-size: 1rem;
-            background: #2a2433; color: #e8e8e8;
-        }
-        .chat-form select {
-            padding: 0.5rem; border: 1px solid #666; border-radius: 4px;
-            background: #2a2433; color: #e8e8e8;
-        }
-        .chat-form button {
-            padding: 0.5rem 1.2rem; background: #0055aa; color: #fff;
-            border: none; border-radius: 4px; cursor: pointer; font-size: 1rem;
-        }
-        .chat-form button:disabled { background: #555; cursor: not-allowed; }
-    </style>
+    <link rel="stylesheet" href="/public/css/redesign/tutor.css">
 </head>
 <body>
 {{template "navflex" .Active}}
 <main role="main">
-    <div class="chat-container">
-        <h2>Go Tutor <small style="font-size:0.6em;color:#aaa">(powered by Claude)</small></h2>
-        <p>Ask any question about Go or the chapters in this repo. Set <code>ANTHROPIC_API_KEY</code> on the server to enable.</p>
+    <section class="container-820 fade-up tutor-section">
+        <div class="kicker">// ask</div>
+        <h1>Tutor</h1>
+        <p class="lede tutor-lede">Stuck on a chapter? Ask a question about Go &mdash; goroutines, interfaces, channels &mdash; and get a focused answer. Set <code>ANTHROPIC_API_KEY</code> on the server to enable.</p>
+
         <div class="chat-box" id="chatBox">
             <div class="chat-msg tutor">Hello! I'm your Go tutor. Ask me anything about Go or the book chapters.</div>
         </div>
+
         <form class="chat-form" id="chatForm" onsubmit="return sendQuestion()">
-            <input type="text" id="questionInput" placeholder="e.g. What is a goroutine?" autocomplete="off" required>
-            <select id="chapterSelect">
-                <option value="">No chapter</option>
-                <option value="1">Chapter 1</option>
-                <option value="2">Chapter 2</option>
-                <option value="3">Chapter 3</option>
-                <option value="5">Chapter 5</option>
-                <option value="6">Chapter 6</option>
-                <option value="7">Chapter 7</option>
-                <option value="8">Chapter 8</option>
-                <option value="9">Chapter 9</option>
-            </select>
-            <button type="submit" id="sendBtn">Ask</button>
+            <textarea id="questionInput" rows="12" placeholder="e.g. When should I use a buffered channel? Paste code, error output, or a full question — there's room." autocomplete="off" required></textarea>
+            <div class="chat-chips">
+                <button type="button" class="chip" data-q="What's the difference between a buffered and an unbuffered channel?" onclick="fillPrompt(this)">buffered vs unbuffered</button>
+                <button type="button" class="chip" data-q="When should I use a sync.Mutex instead of a channel?" onclick="fillPrompt(this)">when to use a mutex</button>
+                <button type="button" class="chip" data-q="How does the select statement work in Go?" onclick="fillPrompt(this)">select statement</button>
+            </div>
+            <div class="chat-actions">
+                <select id="chapterSelect">
+                    <option value="">No chapter</option>
+                    <option value="1">Chapter 1</option>
+                    <option value="2">Chapter 2</option>
+                    <option value="3">Chapter 3</option>
+                    <option value="5">Chapter 5</option>
+                    <option value="6">Chapter 6</option>
+                    <option value="7">Chapter 7</option>
+                    <option value="8">Chapter 8</option>
+                    <option value="9">Chapter 9</option>
+                </select>
+                <button type="submit" id="sendBtn" class="btn btn-accent">Ask &rarr;</button>
+            </div>
         </form>
-    </div>
+    </section>
 </main>
 {{template "footer"}}
 <script>
+function fillPrompt(btn) {
+    var input = document.getElementById('questionInput');
+    input.value = btn.dataset.q;
+    input.focus();
+}
 function parseMarkdown(text) {
     text = text.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
     text = text.replace(/```[^\n]*\n([\s\S]*?)```/g, '<pre><code>$1</code></pre>');

--- a/public/templates/ask.gohtml
+++ b/public/templates/ask.gohtml
@@ -19,7 +19,7 @@
         </div>
 
         <form class="chat-form" id="chatForm" onsubmit="return sendQuestion()">
-            <textarea id="questionInput" rows="12" placeholder="e.g. When should I use a buffered channel? Paste code, error output, or a full question — there's room." autocomplete="off" required></textarea>
+            <textarea id="questionInput" rows="2" placeholder="e.g. When should I use a buffered channel? Paste code, error output, or a full question — there's room." autocomplete="off" required></textarea>
             <div class="chat-chips">
                 <button type="button" class="chip" data-q="What's the difference between a buffered and an unbuffered channel?" onclick="fillPrompt(this)">buffered vs unbuffered</button>
                 <button type="button" class="chip" data-q="When should I use a sync.Mutex instead of a channel?" onclick="fillPrompt(this)">when to use a mutex</button>

--- a/public/templates/ask.gohtml
+++ b/public/templates/ask.gohtml
@@ -12,7 +12,7 @@
     <section class="container-820 fade-up tutor-section">
         <div class="kicker">// ask</div>
         <h1>Tutor</h1>
-        <p class="lede tutor-lede">Stuck on a chapter? Ask a question about Go &mdash; goroutines, interfaces, channels &mdash; and get a focused answer. Set <code>ANTHROPIC_API_KEY</code> on the server to enable.</p>
+        <p class="lede tutor-lede">Stuck on a chapter? Ask a question about Go &mdash; goroutines, interfaces, channels &mdash; and get a focused answer.</p>
 
         <div class="chat-box" id="chatBox">
             <div class="chat-msg tutor">Hello! I'm your Go tutor. Ask me anything about Go or the book chapters.</div>

--- a/public/templates/chapters.gohtml
+++ b/public/templates/chapters.gohtml
@@ -4,41 +4,27 @@
     <meta charset="UTF-8">
     <title>Chapters — The GPL</title>
     {{template "head"}}
-    <link rel="stylesheet" href="/public/css/initial/indextable.css">
-    <style>
-        .chapters-grid {
-            display: grid;
-            grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
-            gap: 1.2rem;
-            padding: 1.5rem;
-        }
-        .chapter-card {
-            border: 1px solid #555;
-            border-radius: 6px;
-            padding: 1rem 1.2rem;
-            background: #2a2433;
-        }
-        .chapter-card h3 { margin: 0 0 0.4rem; font-size: 1.05rem; color: #e8e8e8; text-align: left; }
-        .chapter-card p  { margin: 0; font-size: 0.9rem; color: #b0b0b0; }
-        .chapter-card a  { text-decoration: none; color: #7ab3f7; }
-        .chapter-card:hover { box-shadow: 0 2px 12px rgba(0,0,0,0.4); border-color: #7ab3f7; }
-    </style>
+    <link rel="stylesheet" href="/public/css/redesign/chapters.css">
 </head>
 <body>
 {{template "navflex" .Active}}
 <main role="main">
-    <section style="padding:1rem 1.5rem; color:#e8e8e8">
-        <h2>Book Chapters</h2>
-        <p>Each chapter mirrors a chapter from <em>The Go Programming Language</em> by Donovan &amp; Kernighan.</p>
-    </section>
-    <div class="chapters-grid">
-        {{range .Chapters}}
-        <div class="chapter-card">
-            <h3><a href="{{.Path}}">Chapter {{.Number}} — {{.Title}}</a></h3>
-            <p>{{.Description}}</p>
+    <section class="container-960 fade-up chapters-section">
+        <div class="kicker">// the book</div>
+        <h1>Chapters</h1>
+        <p class="lede chapters-lede">Each chapter mirrors one from <em>The Go Programming Language</em> and ships with the programs that make it concrete.</p>
+        <div class="chapters-list">
+            {{range .Chapters}}
+            <a class="chapter-card" href="{{.Path}}" target="_blank" rel="noopener">
+                <div class="chapter-no">{{printf "%02d" .Number}}</div>
+                <div class="chapter-body">
+                    <h3 class="chapter-title">{{.Title}}</h3>
+                    <p class="chapter-desc">{{.Description}}</p>
+                </div>
+            </a>
+            {{end}}
         </div>
-        {{end}}
-    </div>
+    </section>
 </main>
 {{template "footer"}}
 </body>

--- a/public/templates/demos.gohtml
+++ b/public/templates/demos.gohtml
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Demos — The GPL</title>
+    {{template "head"}}
+    <link rel="stylesheet" href="/public/css/redesign/demos.css">
+</head>
+<body>
+{{template "navflex" .Active}}
+<main role="main">
+    <section class="container fade-up demos-section">
+        <div class="kicker">// server-rendered graphics</div>
+        <h1>Demos</h1>
+        <p class="lede demos-lede">Each plot is generated on the server in Go and streamed back as a GIF or SVG. Open one to see its parameters and run it live.</p>
+        <div class="demo-grid demo-grid-gallery">
+            {{range .Demos}}
+            <a class="demo-card" href="{{.Path}}">
+                <div class="demo-card-preview demo-card-preview-center stripes">
+                    {{if .Preview}}<img class="demo-card-img" src="{{.Preview}}" alt="{{.Name}}" loading="lazy">{{end}}
+                    <span class="badge badge-route demo-card-badge">{{.Route}}</span>
+                </div>
+                <div class="demo-card-body">
+                    <div class="demo-card-body-head">
+                        <div class="demo-card-name">{{.Name}}</div>
+                        <span class="badge badge-tag">{{.Tag}}</span>
+                    </div>
+                    <div class="demo-card-short">{{.Short}}</div>
+                </div>
+            </a>
+            {{end}}
+            <!-- Post Data tool card (not a rendered demo; links to the request inspector) -->
+            <a class="demo-card" href="/post">
+                <div class="demo-card-preview demo-card-preview-center stripes">
+                    <span class="demo-card-plain">/post</span>
+                </div>
+                <div class="demo-card-body">
+                    <div class="demo-card-body-head">
+                        <div class="demo-card-name">Post Data</div>
+                        <span class="badge badge-tag">tool &middot; echo</span>
+                    </div>
+                    <div class="demo-card-short">Send fields and inspect the exact request the server receives.</div>
+                </div>
+            </a>
+        </div>
+    </section>
+</main>
+{{template "footer"}}
+</body>
+</html>

--- a/public/templates/footer.gohtml
+++ b/public/templates/footer.gohtml
@@ -1,11 +1,28 @@
 {{define "footer"}}
-    <footer class="mlk-quote">
-        <section class="mlk-quote-text">
-            <blockquote cite="https://www2.oberlin.edu/external/EOG/BlackHistoryMonth/MLK/MLKmainpage.html">
-                The time is always right to do what is right.
-            </blockquote>
-            <p>Martin Luther King Jr. <cite>1965 Oberlin College commencement speech</cite>.</p>
-        </section>
-        <img class="mlk-quote-img" src="/public/images/misc/mlk.jpg" alt="MLK Picture">
+    <footer class="site-footer">
+        <div class="site-footer-inner">
+            <div class="footer-quote">
+                <blockquote cite="https://www2.oberlin.edu/external/EOG/BlackHistoryMonth/MLK/MLKmainpage.html">
+                    &ldquo;The time is always right to do what is right.&rdquo;
+                </blockquote>
+                <div class="footer-quote-attr">&mdash; Martin Luther King Jr., Oberlin College commencement, 1965</div>
+                <div class="footer-blm">Black Lives Matter</div>
+            </div>
+            <div class="footer-cols">
+                <div class="footer-col">
+                    <div class="footer-col-head">book</div>
+                    <a href="/chapters">Chapters</a>
+                    <a href="/demos">Demos</a>
+                </div>
+                <div class="footer-col">
+                    <div class="footer-col-head">tools</div>
+                    <a href="/post">Post Data</a>
+                    <a href="/ask-page">Tutor</a>
+                </div>
+            </div>
+        </div>
+        <div class="footer-strip">
+            <div class="footer-strip-inner">the-gpl &middot; frontend redesign &middot; backend unchanged</div>
+        </div>
     </footer>
 {{end}}

--- a/public/templates/head.gohtml
+++ b/public/templates/head.gohtml
@@ -2,10 +2,11 @@
 {{define "head"}}
     <link rel="icon" type="image/png" sizes="16x16" href="/public/images/icons/favicon-16x16.png">
     <link rel="icon" type="image/png" sizes="32x32" href="/public/images/icons/favicon-32x32.png">
-    <link rel="stylesheet" href="/public/css/initial/main.css">
-    <link rel="stylesheet" href="/public/css/initial/navflex.css">
-    <link rel="stylesheet" href="/public/css/initial/footer.css">
-    <link rel="preconnect" href="https://fonts.gstatic.com">
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500&display=swap">
+    <link rel="stylesheet" href="/public/css/redesign/main.css">
+    <link rel="stylesheet" href="/public/css/redesign/nav.css">
+    <link rel="stylesheet" href="/public/css/redesign/footer.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;700&display=swap">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 {{end}}

--- a/public/templates/home.gohtml
+++ b/public/templates/home.gohtml
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>The GPL — Working code for The Go Programming Language</title>
+    {{template "head"}}
+    <link rel="stylesheet" href="/public/css/redesign/home.css">
+</head>
+<body>
+{{template "navflex" .Active}}
+<main role="main">
+    <div class="fade-up">
+        <section class="container home-hero">
+            <div class="kicker">// companion site &middot; Go by example</div>
+            <h1 class="hero-title">Working code for <span class="accent-ink">The Go Programming Language</span>.</h1>
+            <p class="lede home-hero-lede">Nine chapters from Donovan &amp; Kernighan, rebuilt as runnable programs &mdash; from goroutines and channels to server-rendered graphics. Read the chapter, then run the demo.</p>
+            <div class="home-hero-actions">
+                <a class="btn btn-dark" href="/chapters">Browse chapters</a>
+                <a class="btn btn-light" href="/demos">See the demos</a>
+            </div>
+        </section>
+
+        <section class="container home-stats-section">
+            <div class="home-stats">
+                {{range .Stats}}
+                <div class="stat card">
+                    <div class="stat-num">{{.Num}}</div>
+                    <div class="stat-label">{{.Label}}</div>
+                </div>
+                {{end}}
+            </div>
+        </section>
+
+        <section class="container home-demos-section">
+            <div class="home-demos-head">
+                <h2>Interactive demos</h2>
+                <a class="home-demos-viewall" href="/demos">view all &rarr;</a>
+            </div>
+            <div class="demo-grid demo-grid-home">
+                {{range .Demos}}
+                <a class="demo-card" href="{{.Path}}">
+                    <div class="demo-card-preview stripes">
+                        {{if .Preview}}<img class="demo-card-img" src="{{.Preview}}" alt="{{.Name}}" loading="lazy">{{end}}
+                        <span class="badge badge-route demo-card-badge">{{.Tag}}</span>
+                    </div>
+                    <div class="demo-card-body">
+                        <div class="demo-card-name">{{.Name}}</div>
+                        <div class="demo-card-short">{{.Short}}</div>
+                    </div>
+                </a>
+                {{end}}
+            </div>
+        </section>
+    </div>
+</main>
+{{template "footer"}}
+</body>
+</html>

--- a/public/templates/index.gohtml
+++ b/public/templates/index.gohtml
@@ -2,53 +2,41 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>The GPL</title>
+    <title>Post Data — The GPL</title>
     {{template "head"}}
-    <link rel="stylesheet" href="/public/css/initial/indextable.css">
+    <link rel="stylesheet" href="/public/css/redesign/post.css">
 </head>
 <body>
-<!-- Horizontal navigation section: Fill in navigation template -->
 {{template "navflex" .Active}}
-
-<!-- Table for Header key/values -->
 <main role="main">
-    <section class="index-first-section">
-        <h3> Data received from this browser by server:</h3>
-        <table class="params">
-            <tr>
-                <th>Header</th>
-                <th>Values</th>
-            </tr>
-            <!-- Fill in the data -->
-            {{range $key, $values := .Data}}
-                <tr>
-                    <td>{{$key}}</td>
-                    <td>{{$values}}</td>
-                </tr>
-            {{end}}
-        </table>
-    </section>
-    <!-- Send data to server as a GET -->
-    <section class="index-table-section">
-        <h4>Send any test attributes using method "get"</h4>
-        <form class="arbitrary-input" action="/" method="get">
-            <div class="input-label-field">
-                <label for="field1" class="input-field-label"> Field 1:</label>
-                <input type="text" name="value1" id="field1" class="input-field-input"
-                       autocomplete="off" placeholder="Try sending any sentence.">
-            </div>
-            <div class="input-label-field">
-                <label for="field2" class="input-field-label"> Field 2:</label>
-                <input type="text" name="value2" id="field2" class="input-field-input"
-                       autocomplete="off" placeholder="Try sending another sentence.">
-            </div>
-            <input type="submit" class="input-field-submit" value="Submit">
+    <section class="container-900 fade-up post-section">
+        <div class="kicker">// request inspector</div>
+        <h1>Post Data</h1>
+        <p class="lede post-lede">Send fields to the server and it echoes back exactly what your browser transmitted &mdash; headers and all.</p>
+
+        <!-- Send data to server as a GET; /post is handled by indexHandler. -->
+        <form class="post-form" action="/post" method="get">
+            <label class="post-field">
+                <span class="post-field-label">field 1</span>
+                <input class="post-input" type="text" name="value1" autocomplete="off" placeholder="anything…">
+            </label>
+            <label class="post-field">
+                <span class="post-field-label">field 2</span>
+                <input class="post-input" type="text" name="value2" autocomplete="off" placeholder="anything…">
+            </label>
+            <button class="btn btn-accent post-submit" type="submit">Send &amp; inspect</button>
         </form>
+
+        <div class="post-response">
+            <div class="post-response-label">headers seen by the server</div>
+            <div class="code-panel">
+                {{range $key, $values := .Data}}
+                <div><span class="k">{{$key}}</span><span class="sep"> : </span><span class="v">{{$values}}</span></div>
+                {{end}}
+            </div>
+        </div>
     </section>
 </main>
-
-<!-- Footer quote -->
 {{template "footer"}}
-
 </body>
 </html>

--- a/public/templates/index.gohtml
+++ b/public/templates/index.gohtml
@@ -10,6 +10,7 @@
 {{template "navflex" .Active}}
 <main role="main">
     <section class="container-900 fade-up post-section">
+        <a class="demo-back" href="/demos">&larr; all demos</a>
         <div class="kicker">// request inspector</div>
         <h1>Post Data</h1>
         <p class="lede post-lede">Send fields to the server and it echoes back exactly what your browser transmitted &mdash; headers and all.</p>

--- a/public/templates/lismandel.gohtml
+++ b/public/templates/lismandel.gohtml
@@ -2,24 +2,42 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>Lissajous</title>
+    <title>{{.Heading}} — The GPL</title>
     {{template "head"}}
-    <link rel="stylesheet" href="/public/css/initial/lismandel.css">
+    <link rel="stylesheet" href="/public/css/redesign/demos.css">
 </head>
 <body>
-
+{{template "navflex" .Active}}
 <main role="main">
-    <!-- Horizontal navigation section: Fill in navigation template -->
-    {{template "navflex" .Active}}
-    <section class="lismandel-info">
-        <!-- Table for Header key/values -->
-        <h3>{{.Heading}}</h3>
+    <section class="container-960 fade-up demo-detail">
+        <a class="demo-back" href="/demos">&larr; all demos</a>
+        <div class="demo-detail-head">
+            <h1>{{.Heading}}</h1>
+            {{if .Tag}}<span class="demo-detail-tag">{{.Tag}}</span>{{end}}
+        </div>
+        {{if .Description}}<p class="lede demo-detail-desc">{{.Description}}</p>{{end}}
 
-        <!-- Add for image -->
-        <img class="lismandel" src="{{.ImageName}}" alt="Computed image">
+        <div class="demo-output">
+            <div class="demo-output-preview stripes">
+                <img class="demo-output-img" src="{{.ImageName}}" alt="{{.Heading}}">
+                <span class="demo-output-badge">rendered output &middot; GET {{.ImageName}}</span>
+                {{if .Format}}<span class="demo-output-format">{{.Format}}</span>{{end}}
+            </div>
+            <div class="demo-params">
+                <div class="demo-params-label">parameters</div>
+                <div class="demo-params-list">
+                    {{range .Params}}
+                    <div class="demo-param">
+                        <code class="demo-param-name">{{.Name}}</code>
+                        <span class="demo-param-note">{{.Note}}</span>
+                    </div>
+                    {{end}}
+                </div>
+                <a class="btn btn-dark demo-run" href="{{.ImageName}}" target="_blank" rel="noopener">Run on server &rarr;</a>
+            </div>
+        </div>
     </section>
-    <!-- Footer quote -->
-    {{template "footer"}}
 </main>
+{{template "footer"}}
 </body>
 </html>

--- a/public/templates/navflex.gohtml
+++ b/public/templates/navflex.gohtml
@@ -1,33 +1,37 @@
 {{define "navflex"}}
-    <aside class="the-gpl-header-and-nav">
-        <!--- Quote at top of every page -->
-        <q class="the-gpl-header-title" cite="https://blacklivesmatter.com/">Black Lives Matter</q>
-        <header class="the-gpl-header">
-            <button class="nav-hamburger" id="navToggle" aria-label="Menu" aria-expanded="false">&#9776; Menu</button>
-            <!--- Navigation bar, . is name of Active page  -->
-            <nav class="flex-navigation" id="flexNav">
-                <div class="flex-nav-tab"><a{{if eq . "post"}} class="flex-nav-active" {{end}} href="post">Post Data</a></div>
-                <div class="flex-nav-tab"><a{{if eq . "lis"}} class="flex-nav-active" {{end}} href="lis">Lissajous</a></div>
-                <div class="flex-nav-tab"><a{{if eq . "sinc"}} class="flex-nav-active" {{end}} href="sinc">Sinc</a></div>
-                <div class="flex-nav-tab"><a{{if eq . "egg"}} class="flex-nav-active" {{end}} href="egg">Egg</a></div>
-                <div class="flex-nav-tab"><a{{if eq . "valley"}} class="flex-nav-active" {{end}} href="valley">Valley</a></div>
-                <div class="flex-nav-tab"><a{{if eq . "sq"}} class="flex-nav-active" {{end}} href="sq">Squares</a></div>
-                <div class="flex-nav-tab"><a{{if eq . "chapters"}} class="flex-nav-active" {{end}} href="chapters">Chapters</a></div>
-                <div class="flex-nav-tab"><a{{if eq . "ask"}} class="flex-nav-active" {{end}} href="ask-page">Tutor</a></div>
-                <div class="flex-nav-tab flex-nav-tab-last-spacer"></div>
-                <div class="flex-nav-tab flex-nav-tab-last"><a{{if eq . "about"}} class="flex-nav-active" {{end}} href="about">About</a></div>
+    <header class="site-header">
+        <div class="site-header-inner">
+            <a class="wordmark" href="/">
+                <span class="wordmark-glyph">g</span>
+                <span class="wordmark-text">the-gpl</span>
+            </a>
+            <!-- Desktop nav. . is the Active page string. -->
+            <nav class="site-nav">
+                <a class="nav-pill{{if eq . "chapters"}} active{{end}}" href="/chapters">Chapters</a>
+                <a class="nav-pill{{if eq . "demos" "lis" "mandel" "mandelbw" "sinc" "egg" "valley" "sq"}} active{{end}}" href="/demos">Demos</a>
+                <a class="nav-pill{{if eq . "ask"}} active{{end}}" href="/ask-page">Tutor</a>
+                <a class="nav-pill{{if eq . "about"}} active{{end}}" href="/about">About</a>
             </nav>
-        </header>
-    </aside>
+            <button class="nav-toggle" id="navToggle" aria-label="Menu" aria-expanded="false">
+                <span></span><span></span><span></span>
+            </button>
+        </div>
+        <!-- Mobile sheet -->
+        <div class="nav-sheet" id="navSheet">
+            <a class="nav-pill{{if eq . "chapters"}} active{{end}}" href="/chapters">Chapters</a>
+            <a class="nav-pill{{if eq . "demos" "lis" "mandel" "mandelbw" "sinc" "egg" "valley" "sq"}} active{{end}}" href="/demos">Demos</a>
+            <a class="nav-pill{{if eq . "ask"}} active{{end}}" href="/ask-page">Tutor</a>
+            <a class="nav-pill{{if eq . "about"}} active{{end}}" href="/about">About</a>
+        </div>
+    </header>
     <script>
     (function(){
         var btn = document.getElementById('navToggle');
-        var nav = document.getElementById('flexNav');
-        if (!btn || !nav) return;
+        var sheet = document.getElementById('navSheet');
+        if (!btn || !sheet) return;
         btn.addEventListener('click', function() {
-            var open = nav.classList.toggle('nav-open');
+            var open = sheet.classList.toggle('open');
             btn.setAttribute('aria-expanded', String(open));
-            btn.innerHTML = open ? '&#10005; Close' : '&#9776; Menu';
         });
     })();
     </script>

--- a/public/templates/socialcard.gohtml
+++ b/public/templates/socialcard.gohtml
@@ -1,13 +1,19 @@
 {{define "socialcard"}}
     {{if .}}
-        <div class="cards">
-            {{range $idx, $card := .}}
-                <div class="card">
-                    <img src="{{$card.Image}}" alt="{{$card.ImageAlt}}">
-                    <h3>{{$card.Title}}</h3>
-                    <h4>{{$card.SocialMessage}} <a href="{{$card.SocialLink}}"
-                                                   target="_blank">{{$card.SocialHandle}}</a></h4>
-                </div>
+        <div class="social-grid">
+            {{range $card := .}}
+                <a class="social-card" href="{{$card.SocialLink}}" target="_blank" rel="noopener">
+                    <div class="social-card-cover">
+                        <img src="{{$card.Image}}" alt="{{$card.ImageAlt}}" loading="lazy">
+                    </div>
+                    <div class="social-card-body">
+                        <span class="social-card-meta">
+                            <span class="social-card-platform">{{$card.Title}}</span>
+                            <span class="social-card-handle">{{$card.SocialHandle}}</span>
+                        </span>
+                        <span class="social-card-arrow">&rarr;</span>
+                    </div>
+                </a>
             {{end}}
         </div>
     {{end}}

--- a/public/templates/surfaces.gohtml
+++ b/public/templates/surfaces.gohtml
@@ -2,24 +2,42 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>{{.Active}}</title>
+    <title>{{.Heading}} — The GPL</title>
     {{template "head"}}
+    <link rel="stylesheet" href="/public/css/redesign/demos.css">
 </head>
 <body>
-
+{{template "navflex" .Active}}
 <main role="main">
-    <!-- Horizontal navigation section: Fill in navigation template -->
-    {{template "navflex" .Active}}
+    <section class="container-960 fade-up demo-detail">
+        <a class="demo-back" href="/demos">&larr; all demos</a>
+        <div class="demo-detail-head">
+            <h1>{{.Heading}}</h1>
+            {{if .Tag}}<span class="demo-detail-tag">{{.Tag}}</span>{{end}}
+        </div>
+        {{if .Description}}<p class="lede demo-detail-desc">{{.Description}}</p>{{end}}
 
-    <section class="surfaces-info">
-        <!-- Table for Header key/values -->
-        <h3>{{.Heading}}</h3>
-
-        <!-- Image SVG Content -->
-        <object data="{{.SVGImageName}}" type="image/svg+xml"></object>
+        <div class="demo-output">
+            <div class="demo-output-preview stripes">
+                <img class="demo-output-img" src="{{.SVGImageName}}" alt="{{.Heading}}">
+                <span class="demo-output-badge">rendered output &middot; GET {{.SVGImageName}}</span>
+                {{if .Format}}<span class="demo-output-format">{{.Format}}</span>{{end}}
+            </div>
+            <div class="demo-params">
+                <div class="demo-params-label">parameters</div>
+                <div class="demo-params-list">
+                    {{range .Params}}
+                    <div class="demo-param">
+                        <code class="demo-param-name">{{.Name}}</code>
+                        <span class="demo-param-note">{{.Note}}</span>
+                    </div>
+                    {{end}}
+                </div>
+                <a class="btn btn-dark demo-run" href="{{.SVGImageName}}" target="_blank" rel="noopener">Run on server &rarr;</a>
+            </div>
+        </div>
     </section>
-    <!-- Footer quote -->
-    {{template "footer"}}
 </main>
+{{template "footer"}}
 </body>
 </html>

--- a/serve/web/demodata.go
+++ b/serve/web/demodata.go
@@ -1,0 +1,107 @@
+package web
+
+// This file holds the static data shown on the home page and the /demos
+// gallery, plus per-demo metadata for the demo-detail pages. It mirrors the
+// pattern in socialcarddata.go: package-level vars, no logic.
+
+// homeStats are the three headline numbers on the landing page.
+var homeStats = []Stat{
+	{Num: "9", Label: "book chapters, rebuilt as code"},
+	{Num: "5", Label: "live server-rendered demos"},
+	{Num: "Go", Label: "one language, front to back"},
+}
+
+// demoCards are the five live demos shown in the home strip and the /demos
+// gallery. Previews point at real rendered assets: the Lissajous GIF and the
+// live SVG surface endpoints (all served by existing handlers). The Mandelbrot
+// pages are reachable and restyled but intentionally not listed here.
+var demoCards = []DemoCard{
+	{Name: "Lissajous", Path: "/lis", Route: "/lis", Tag: "ch.1 · GIF",
+		Short: "Animated Lissajous curves.", Preview: "/public/images/media/lis.gif"},
+	{Name: "Sinc", Path: "/sinc", Route: "/sinc", Tag: "ch.3 · SVG",
+		Short: "3-D sinc surface, scalable SVG.", Preview: sincSVGImagePath},
+	{Name: "Egg", Path: "/egg", Route: "/egg", Tag: "ch.3 · SVG",
+		Short: "Parametric egg surface.", Preview: eggSVGImagePath},
+	{Name: "Valley", Path: "/valley", Route: "/valley", Tag: "ch.3 · SVG",
+		Short: "Saddle / valley surface plot.", Preview: valleySVGImagePath},
+	{Name: "Squares", Path: "/sq", Route: "/sq", Tag: "ch.3 · SVG",
+		Short: "Tiled squares surface.", Preview: sqSVGImagePath},
+}
+
+// demoMetaEntry is the per-demo copy shown on a demo-detail page. Params are
+// display-only: the endpoints accept no query parameters, so these describe the
+// fixed server-side render settings (values verified against chapter1/chapter3).
+type demoMetaEntry struct {
+	Tag         string
+	Description string
+	Format      string
+	Params      []DemoParam
+}
+
+// surfaceParams are shared by the four 3-D surface plots — all use the same
+// projection pipeline (chapter3/constants.go).
+var surfaceParams = []DemoParam{
+	{Name: "cells", Note: "50 × 50 sample grid per axis"},
+	{Name: "range", Note: "x, y swept over −30 … +30"},
+	{Name: "angle", Note: "30° isometric projection"},
+}
+
+// mandelParams are shared by both Mandelbrot renderers (chapter3/constants.go).
+var mandelParams = []DemoParam{
+	{Name: "x range", Note: "−2 … +2 on the real axis"},
+	{Name: "y range", Note: "−2 … +2 on the imaginary axis"},
+	{Name: "size", Note: "1024 × 1024 px"},
+	{Name: "iterations", Note: "255 escape-time cap"},
+}
+
+// demoMeta is keyed by the Active page string (Lis.String(), Sinc.String(), …)
+// so imageHandler/surfaceHandler can look it up with their activePage argument.
+var demoMeta = map[string]demoMetaEntry{
+	"lis": {
+		Tag:         "ch.1 · GIF",
+		Format:      "image/gif · animated",
+		Description: "Two perpendicular sine waves traced over time and encoded as an animated GIF entirely on the server — the classic chapter-1 concurrency-and-graphics warmup.",
+		Params: []DemoParam{
+			{Name: "cycles", Note: "4 complete x-oscillations"},
+			{Name: "resolution", Note: "0.001 rad angular step"},
+			{Name: "size", Note: "512 px canvas half-size"},
+			{Name: "nframes", Note: "6 frames, 20 ms delay"},
+		},
+	},
+	"sinc": {
+		Tag:         "ch.3 · SVG",
+		Format:      "image/svg+xml",
+		Description: "The sinc(r) = sin(r)/r surface projected isometrically and emitted as resolution-independent SVG polygons.",
+		Params:      surfaceParams,
+	},
+	"egg": {
+		Tag:         "ch.3 · SVG",
+		Format:      "image/svg+xml",
+		Description: "A parametric egg-shaped surface rendered as an SVG wireframe using the same 3-D projection pipeline as the other surface plots.",
+		Params:      surfaceParams,
+	},
+	"valley": {
+		Tag:         "ch.3 · SVG",
+		Format:      "image/svg+xml",
+		Description: "A saddle surface that dips into a valley, plotted as SVG to show off scalable vector output from Go.",
+		Params:      surfaceParams,
+	},
+	"sq": {
+		Tag:         "ch.3 · SVG",
+		Format:      "image/svg+xml",
+		Description: "A tiled-squares height field rendered as SVG — the simplest of the surface-plot family and a good baseline for the projection math.",
+		Params:      surfaceParams,
+	},
+	"mandel": {
+		Tag:         "ch.3 · PNG",
+		Format:      "image/png · 4× super-sampled",
+		Description: "The Mandelbrot set escape-time coloured and anti-aliased with 4× super-sampling, computed across goroutines and streamed back as a PNG.",
+		Params:      mandelParams,
+	},
+	"mandelbw": {
+		Tag:         "ch.3 · PNG",
+		Format:      "image/png · greyscale",
+		Description: "The Mandelbrot set rendered in greyscale by escape-time iteration count — the black-and-white companion to the coloured render.",
+		Params:      mandelParams,
+	},
+}

--- a/serve/web/pagedata.go
+++ b/serve/web/pagedata.go
@@ -26,6 +26,10 @@ const (
 	Chapters Active = "chapters"
 	// Ask is the AI tutor chat page
 	Ask Active = "ask"
+	// Home is the landing page
+	Home Active = "home"
+	// Demos lists the interactive demos
+	Demos Active = "demos"
 )
 
 // IndexPageData contains Active Page name and Data for the index page
@@ -40,9 +44,19 @@ type AboutPageData struct {
 	Data   []SocialCard
 }
 
+// DemoParam is one display-only parameter row on a demo-detail page.
+// The demo endpoints accept no query params, so these describe the fixed
+// server-side render settings.
+type DemoParam struct {
+	Name string
+	Note string
+}
+
 // ImagesPageData defines data for templates
 type ImagesPageData struct {
 	Active, ImageName, Heading string
+	Tag, Description, Format   string
+	Params                     []DemoParam
 }
 
 // ImagePath lists URL paths  for SVG surfaces
@@ -72,6 +86,39 @@ type SVGPageData struct {
 	Active       string
 	SVGImageName string
 	Heading      string
+	Tag          string
+	Description  string
+	Format       string
+	Params       []DemoParam
+}
+
+// Stat is one headline number shown on the home page.
+type Stat struct {
+	Num   string
+	Label string
+}
+
+// DemoCard is one card in the home demos strip and the /demos gallery.
+type DemoCard struct {
+	Name    string
+	Path    string // page route, e.g. "/lis"
+	Route   string // badge text, e.g. "/lis"
+	Tag     string // e.g. "ch.1 · GIF"
+	Short   string
+	Preview string // asset URL for the card thumbnail; empty renders stripes only
+}
+
+// HomePageData is the template data for the landing page at "/".
+type HomePageData struct {
+	Active string
+	Stats  []Stat
+	Demos  []DemoCard
+}
+
+// DemosPageData is the template data for the /demos gallery.
+type DemosPageData struct {
+	Active string
+	Demos  []DemoCard
 }
 
 // SVGSurfacePath lists URL paths  for SVG surfaces
@@ -113,6 +160,10 @@ const (
 	ChaptersPage = "chapters.gohtml"
 	// AskPage shows the AI tutor chat UI
 	AskPage = "ask.gohtml"
+	// HomePage is the landing page
+	HomePage = "home.gohtml"
+	// DemosPage lists the interactive demos
+	DemosPage = "demos.gohtml"
 	// LisMandelPage shows Lissajous and Mandelbrot images
 	LisMandelPage = "lismandel.gohtml"
 	// SurfacesPage shows computed SVG images

--- a/serve/web/socialcarddata.go
+++ b/serve/web/socialcarddata.go
@@ -1,51 +1,54 @@
 package web
 
-// SocialCard defines data on a social card
+// SocialCard defines data on a social card. Title is the platform name,
+// SocialHandle the account handle, SocialLink the profile URL, and Image an
+// absolute path under /public. SocialMessage is retained for compatibility but
+// is not rendered by the redesigned card.
 type SocialCard struct {
 	Image, ImageAlt                         string
 	Title                                   string
 	SocialMessage, SocialLink, SocialHandle string
 }
 
-// twitter info
-var twitter = SocialCard{
-	Image:         "public/images/misc/boris-smokrovic.jpg",
-	ImageAlt:      "Bird image",
-	Title:         "On Twitter",
-	SocialMessage: "Follow",
-	SocialLink:    "//twitter.com/rgplpaa/",
-	SocialHandle:  "@rgplpaa",
+// github info
+var github = SocialCard{
+	Image:         "/public/images/misc/ilya-pavlov.jpg",
+	ImageAlt:      "GitHub",
+	Title:         "GitHub",
+	SocialMessage: "Code",
+	SocialLink:    "https://github.com/opendroid/the-gpl",
+	SocialHandle:  "@opendroid/the-gpl",
 }
 
 // linkedin info
 var linkedin = SocialCard{
-	Image:         "public/images/misc/rgplpaa.jpeg",
-	ImageAlt:      "Linkedin image",
-	Title:         "On Linkedin",
+	Image:         "/public/images/misc/rgplpaa.jpeg",
+	ImageAlt:      "LinkedIn",
+	Title:         "LinkedIn",
 	SocialMessage: "Connect",
-	SocialLink:    "//www.linkedin.com/in/ajaythakur/",
-	SocialHandle:  "@Ajay",
+	SocialLink:    "https://www.linkedin.com/in/ajaythakur/",
+	SocialHandle:  "@ajaythakur",
 }
 
-// GitHub info
-var github = SocialCard{
-	Image:         "public/images/misc/ilya-pavlov.jpg",
-	ImageAlt:      "Coding image",
-	Title:         "On Github",
-	SocialMessage: "Code",
-	SocialLink:    "//github.com/opendroid/the-gpl",
-	SocialHandle:  "@OpenDroid",
+// twitter info
+var twitter = SocialCard{
+	Image:         "/public/images/misc/boris-smokrovic.jpg",
+	ImageAlt:      "Twitter",
+	Title:         "Twitter",
+	SocialMessage: "Follow",
+	SocialLink:    "https://twitter.com/rgplpaa/",
+	SocialHandle:  "@rgplpaa",
 }
 
 // youtube info
 var youtube = SocialCard{
-	Image:         "public/images/misc/donovan-silva.jpg",
-	ImageAlt:      "Youtube link",
-	Title:         "On YouTube",
+	Image:         "/public/images/misc/donovan-silva.jpg",
+	ImageAlt:      "YouTube",
+	Title:         "YouTube",
 	SocialMessage: "Enjoy",
-	SocialLink:    "//www.youtube.com/c/AjayThakur",
-	SocialHandle:  "@OpenWeb",
+	SocialLink:    "https://www.youtube.com/c/AjayThakur",
+	SocialHandle:  "@AjayThakur",
 }
 
-// socialCards static data-base of all cards data.
-var socialCards = []SocialCard{twitter, linkedin, github, youtube}
+// socialCards static data-base of all cards data, in display order.
+var socialCards = []SocialCard{github, linkedin, twitter, youtube}

--- a/serve/web/web.go
+++ b/serve/web/web.go
@@ -30,7 +30,9 @@ var gateway *clients.Gateway
 
 // handlers stores URLS to HandlerFunc
 var handlers = map[string]func(http.ResponseWriter, *http.Request){
-	"/":                  indexHandler, // 	"/" - root page
+	"/":                  homeHandler,  // 	"/" - landing page (also 404-guards unknown paths)
+	"/post":              indexHandler, // request inspector (was reached via "/" catch-all)
+	"/demos":             demosHandler,
 	"/test":              testHandler,
 	"/lisimage.gif":      lissajous.Figure,
 	"/mandelimage.png":   chapter3.MBGraphHandler,

--- a/serve/web/web_test.go
+++ b/serve/web/web_test.go
@@ -1,10 +1,37 @@
 package web
 
 import (
+	"html/template"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
+
+// withRealTemplates swaps the package-level templates var to the real template
+// glob (the running server uses public/templates/*.gohtml relative to the repo
+// root; tests run from serve/web/, so reach up two levels). It restores the
+// original — the dummy shim glob — on cleanup. Parsing the real glob here also
+// means a template syntax error or {{define}} collision fails CI instead of
+// panicking the server at startup.
+func withRealTemplates(t *testing.T) {
+	t.Helper()
+	orig := templates
+	templates = template.Must(template.ParseGlob("../../public/templates/*.gohtml"))
+	t.Cleanup(func() { templates = orig })
+}
+
+// serve runs a handler against a GET request for path and returns the recorder.
+func serve(t *testing.T, h http.HandlerFunc, path string) *httptest.ResponseRecorder {
+	t.Helper()
+	req, err := http.NewRequest("GET", path, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	return rr
+}
 
 // Test_rootHandler tests the server
 //
@@ -56,5 +83,89 @@ func Test_incrHandler(t *testing.T) {
 	expected := "URL: \"/incr\"\n"
 	if rr.Body.String() != expected {
 		t.Errorf("incrHandler: received body: %v expected: %v", rr.Body.String(), expected)
+	}
+}
+
+// Test_homeHandler renders the landing page at "/" and 404s unknown paths.
+func Test_homeHandler(t *testing.T) {
+	withRealTemplates(t)
+
+	rr := serve(t, homeHandler, "/")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("homeHandler /: status %d, want %d", rr.Code, http.StatusOK)
+	}
+	body := rr.Body.String()
+	for _, want := range []string{"The Go Programming Language", "/demos", "/chapters"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("homeHandler /: body missing %q", want)
+		}
+	}
+
+	// Unknown path must 404 (the "/" catch-all guard).
+	rr = serve(t, homeHandler, "/nope")
+	if rr.Code != http.StatusNotFound {
+		t.Errorf("homeHandler /nope: status %d, want %d", rr.Code, http.StatusNotFound)
+	}
+}
+
+// Test_demosHandler renders the /demos gallery with the demo cards and Post card.
+func Test_demosHandler(t *testing.T) {
+	withRealTemplates(t)
+	rr := serve(t, demosHandler, "/demos")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("demosHandler: status %d, want %d", rr.Code, http.StatusOK)
+	}
+	body := rr.Body.String()
+	for _, want := range []string{"Demos", "Lissajous", "/lis", "Post Data"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("demosHandler: body missing %q", want)
+		}
+	}
+}
+
+// Test_chaptersHandler renders /chapters with GitHub source links.
+func Test_chaptersHandler(t *testing.T) {
+	withRealTemplates(t)
+	rr := serve(t, chaptersHandler, "/chapters")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("chaptersHandler: status %d, want %d", rr.Code, http.StatusOK)
+	}
+	body := rr.Body.String()
+	for _, want := range []string{"Chapters", "Tutorial", "github.com/opendroid/the-gpl/tree/master/chapter1"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("chaptersHandler: body missing %q", want)
+		}
+	}
+}
+
+// Test_postPage renders the request inspector at /post with the real form contract.
+func Test_postPage(t *testing.T) {
+	withRealTemplates(t)
+	rr := serve(t, indexHandler, "/post")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("indexHandler /post: status %d, want %d", rr.Code, http.StatusOK)
+	}
+	body := rr.Body.String()
+	for _, want := range []string{`name="value1"`, `name="value2"`, `action="/post"`} {
+		if !strings.Contains(body, want) {
+			t.Errorf("indexHandler /post: body missing %q", want)
+		}
+	}
+}
+
+// Test_demoDetail renders a demo-detail page via imageHandler and checks that the
+// demoMeta (tag, params) is injected.
+func Test_demoDetail(t *testing.T) {
+	withRealTemplates(t)
+	h := imageHandler(Lis.String(), LisImageHanding, lisImagePath)
+	rr := serve(t, h, "/lis")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("imageHandler /lis: status %d, want %d", rr.Code, http.StatusOK)
+	}
+	body := rr.Body.String()
+	for _, want := range []string{LisImageHanding, "ch.1 · GIF", "cycles", "all demos", lisImagePath} {
+		if !strings.Contains(body, want) {
+			t.Errorf("imageHandler /lis: body missing %q", want)
+		}
 	}
 }

--- a/serve/web/webtpl.go
+++ b/serve/web/webtpl.go
@@ -72,6 +72,30 @@ func indexHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// homeHandler renders the landing page at "/". Because net/http's "/" pattern
+// is a catch-all, this also guards unknown paths: anything other than "/" gets
+// a 404 instead of silently rendering the home page.
+func homeHandler(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/" {
+		http.NotFound(w, r)
+		return
+	}
+	slog.Info("homeHandler.")
+	data := HomePageData{Active: Home.String(), Stats: homeStats, Demos: demoCards}
+	if err := templates.ExecuteTemplate(w, HomePage, &data); err != nil {
+		slog.Error("homeHandler", "err", err)
+	}
+}
+
+// demosHandler renders the /demos gallery of interactive demos.
+func demosHandler(w http.ResponseWriter, _ *http.Request) {
+	slog.Info("demosHandler.")
+	data := DemosPageData{Active: Demos.String(), Demos: demoCards}
+	if err := templates.ExecuteTemplate(w, DemosPage, &data); err != nil {
+		slog.Error("demosHandler", "err", err)
+	}
+}
+
 // aboutHandler parses about templates and presents to use
 func aboutHandler(w http.ResponseWriter, _ *http.Request) {
 	slog.Info("aboutHandler.")
@@ -82,13 +106,18 @@ func aboutHandler(w http.ResponseWriter, _ *http.Request) {
 
 // imageHandler injects image template data in LisMandelPage
 func imageHandler(activePage, heading, imagePath string) http.HandlerFunc {
+	meta := demoMeta[activePage]
 	return func(w http.ResponseWriter, r *http.Request) {
 		slog.Info("imageHandler", "path", r.URL.Path)
 		if err := templates.ExecuteTemplate(w, LisMandelPage,
 			&ImagesPageData{
-				Active:    activePage,
-				ImageName: imagePath,
-				Heading:   heading,
+				Active:      activePage,
+				ImageName:   imagePath,
+				Heading:     heading,
+				Tag:         meta.Tag,
+				Description: meta.Description,
+				Format:      meta.Format,
+				Params:      meta.Params,
 			}); err != nil {
 			slog.Error("imageHandler", "path", imagePath, "err", err)
 		}
@@ -97,6 +126,7 @@ func imageHandler(activePage, heading, imagePath string) http.HandlerFunc {
 
 // surfaceHandler injects surface template data in SurfacesPage
 func surfaceHandler(activePage, heading, svgPage string) http.HandlerFunc {
+	meta := demoMeta[activePage]
 	return func(w http.ResponseWriter, r *http.Request) {
 		slog.Info("surfaceHandler", "path", r.URL.Path)
 		// Execute the Surface template with appropriate data
@@ -104,6 +134,10 @@ func surfaceHandler(activePage, heading, svgPage string) http.HandlerFunc {
 			Active:       activePage,
 			SVGImageName: svgPage,
 			Heading:      heading,
+			Tag:          meta.Tag,
+			Description:  meta.Description,
+			Format:       meta.Format,
+			Params:       meta.Params,
 		}); err != nil {
 			slog.Error("surfaceHandler", "err", err)
 		}
@@ -134,21 +168,26 @@ func gzipSVG(handler func(writer io.Writer)) http.HandlerFunc {
 	}
 }
 
+// chapterURL returns the GitHub source directory for a chapter number.
+func chapterURL(n int) string {
+	return fmt.Sprintf("https://github.com/opendroid/the-gpl/tree/master/chapter%d", n)
+}
+
 // chaptersHandler renders the /chapters page listing all book chapters.
 func chaptersHandler(w http.ResponseWriter, _ *http.Request) {
 	slog.Info("chaptersHandler.")
 	data := ChaptersPageData{
 		Active: Chapters.String(),
 		Chapters: []ChapterEntry{
-			{1, "Tutorial", "Goroutines, channels, CLI utilities, Lissajous GIF, Dialogflow bot, Speech-to-Text.", "/chapters"},
-			{2, "Program Structure", "Bit counting (three strategies), temperature conversion types, package-level vars.", "/chapters"},
-			{3, "Basic Data Types", "Mandelbrot PNG, 3-D surface plots (SVG), string utilities.", "/chapters"},
-			{4, "Composite Types", "JSON marshalling, HTML templating, GitHub issue search.", "/chapters"},
-			{5, "Functions", "HTML traversal, web crawler, topological sort, variadic max/min, generic MaxOf/MinOf.", "/chapters"},
-			{6, "Methods", "IntSet bit-vector: Union, Intersect, Difference, SymmetricDifference.", "/chapters"},
-			{7, "Interfaces", "Writer implementations, CountWriter, BroadcastWriters, temperature flag.", "/chapters"},
-			{8, "Goroutines & Channels", "TCP services (clock, reverb, chat, FTP), concurrent DU, web search with context.", "/chapters"},
-			{9, "Concurrency / Shared Variables", "sync.Mutex SafeBank, sync.RWMutex RWBank, sync.Once Icon, Memo cache.", "/chapters"},
+			{1, "Tutorial", "Goroutines, channels, CLI utilities, the Lissajous GIF, a Dialogflow bot, and Speech-to-Text.", chapterURL(1)},
+			{2, "Program Structure", "Bit counting via three strategies, temperature-conversion types, and package-level variables.", chapterURL(2)},
+			{3, "Basic Data Types", "Mandelbrot PNG, 3-D surface plots as SVG, and string utilities.", chapterURL(3)},
+			{4, "Composite Types", "JSON marshalling, HTML templating, and GitHub issue search.", chapterURL(4)},
+			{5, "Functions", "HTML traversal, a web crawler, topological sort, variadic max/min, generic MaxOf/MinOf.", chapterURL(5)},
+			{6, "Methods", "An IntSet bit-vector: Union, Intersect, Difference, SymmetricDifference.", chapterURL(6)},
+			{7, "Interfaces", "Writer implementations, CountWriter, BroadcastWriters, and a temperature flag.", chapterURL(7)},
+			{8, "Goroutines & Channels", "TCP services (clock, reverb, chat, FTP), concurrent du, and web search with context.", chapterURL(8)},
+			{9, "Concurrency & Shared Variables", "sync.Mutex SafeBank, sync.RWMutex RWBank, sync.Once Icon, and a Memo cache.", chapterURL(9)},
 		},
 	}
 	if err := templates.ExecuteTemplate(w, ChaptersPage, &data); err != nil {


### PR DESCRIPTION
Implements the UX redesign from the `design_handoff_the_gpl_redesign` package: a light, minimal theme (warm off-white `#f7f6f3`, teal `#0d8a86` accent, Helvetica UI + JetBrains Mono, flat bordered cards, no shadows) replacing the dark Roboto theme.

Closes #62.

## What changed

**Theme & templates**
- New stylesheet set `public/css/redesign/{main,nav,footer,home,demos,chapters,post,tutor,about}.css` — design tokens as CSS custom properties in `main.css`; `public/css/initial/` is untouched and remains the rollback path (switch the links in `head.gohtml`).
- All templates restyled; shared shell (`head`/`navflex`/`footer` partials) rebuilt: sticky blurred 64px header with teal "g" wordmark, nav **Chapters · Demos · Tutor · About**, MLK-quote footer with book/tools link columns.
- New pages: `home.gohtml` (hero + stats + demos strip) and `demos.gohtml` (gallery of 5 live demos + Post Data tool card).
- Inline `<style>` blocks removed from `ask.gohtml`/`chapters.gohtml` into the CSS set.
- Single 760px breakpoint: hamburger + stacked menu sheet below it.

**Go wiring (minimal, additive)**
- `/` → new `homeHandler`; `/post` registered to the existing `indexHandler` (request inspector, logic untouched — still also at `/index`); new `/demos` → `demosHandler`.
- Static presentation data in `serve/web/demodata.go` (stats, demo cards, per-demo metadata); `ImagesPageData`/`SVGPageData` gained display-only `Tag/Description/Format/Params` fields.
- Chapter cards now link to their GitHub source directories.
- Tests: `withRealTemplates` swaps in the real template glob, so template syntax errors now fail CI instead of panicking at server startup; handler render tests added for home/demos/chapters/post/demo-detail.

## Backend contract

All existing routes, handlers, form field names (`value1`/`value2`), and raw image/SVG/API endpoints are unchanged: `/lisimage.gif`, `/mandelimage.png`, `/mandelbwimage.png`, `*SVG.svg`, `/ask`, `/search`, `/who`, `/counter`, `/test`, SEO files.

**One deliberate behavior change**: `homeHandler` 404s unknown paths. Previously net/http's `"/"` catch-all rendered the index page for every unmatched URL.

## Validation

- `go build ./...`, `go vet ./...`, `gofmt -l .`, `golangci-lint run --new-from-rev=master`, `go test ./...` — all clean.
- Every page route + raw/API route smoke-tested (status + content type), including the 404 guard.
- Browser pass (desktop + <760px mobile): all pages match the handoff, active-nav state correct (Demos pill lit on demo-detail pages), hamburger sheet works, zero console errors.
- Functional: Post Data form round-trip echoes `value1`/`value2` in the dark header panel on `/post` and `/index`; Tutor chip → prefill → Ask → live Claude answer rendered via the markdown parser; "Run on server →" opens raw assets; chapter cards open GitHub.
- Demo-detail "parameters" verified against the Go source (`chapter1/lissajous`, `chapter3/constants.go`, 255-iteration Mandelbrot cap) — they document the real fixed render settings.

## Deviations from the handoff (intentional)

- **Tutor** keeps the working fetch-based chat and the chapter `<select>` (feeds the real `&chapter=` param) instead of the prototype's inert GET form; suggestion chips prefill the input.
- **Demo params are display-only** — the endpoints accept no query parameters, so they're presented as fixed render settings, not inputs.
- **Mandelbrot pages** (`/mandel`, `/mandelbw`) are restyled with the demo-detail layout but stay unlisted (same discoverability as before; keeps the "5 live demos" stat truthful).

## Known pre-existing nits (out of scope)

- `fileHandler` sends `Cache-Control: 31536000` (missing `max-age=`) — one-line fix for a future PR.
- `chapter1/lissajous` tests regenerate `public/images/media/lis*.gif` as a side effect of `go test ./...`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
