### PR TITLE
Tutor page: chapter-aware suggestions, editable default, cached answers

### DIFF
--- a/clients/tutorcache.go
+++ b/clients/tutorcache.go
@@ -1,0 +1,125 @@
+package clients
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"cloud.google.com/go/firestore"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// TutorCache stores and retrieves previously answered tutor questions by an
+// exact-match key (see TutorCacheKey). Implementations must be safe for
+// concurrent use.
+type TutorCache interface {
+	// Get returns the cached answer for key and whether it was found.
+	Get(ctx context.Context, key string) (answer string, found bool, err error)
+	// Put stores answer under key, along with the originating question and
+	// chapter for readability in the backing store.
+	Put(ctx context.Context, key, question, chapter, answer string) error
+}
+
+const (
+	tutorCacheCollection = "tutor_cache"
+	tutorProjectEnv      = "GOOGLE_CLOUD_PROJECT"
+)
+
+// TutorCacheKey builds a stable exact-match key from a question and chapter.
+// The question is normalized (surrounding and repeated whitespace collapsed,
+// lower-cased) so trivial formatting differences map to the same entry; the
+// chapter scopes the key so identical text under different chapters caches
+// separately.
+func TutorCacheKey(question, chapter string) string {
+	normalized := strings.ToLower(strings.Join(strings.Fields(question), " "))
+	sum := sha256.Sum256([]byte(chapter + "\n" + normalized))
+	return hex.EncodeToString(sum[:])
+}
+
+// memoryCache is an in-process TutorCache used for local/dev and as a fallback
+// when Firestore is unavailable. Entries live for the process lifetime.
+type memoryCache struct {
+	mu sync.RWMutex
+	m  map[string]string
+}
+
+func newMemoryCache() *memoryCache { return &memoryCache{m: make(map[string]string)} }
+
+// NewMemoryTutorCache returns an in-process TutorCache. Useful for tests or when
+// persistence is explicitly not wanted.
+func NewMemoryTutorCache() TutorCache { return newMemoryCache() }
+
+func (c *memoryCache) Get(_ context.Context, key string) (string, bool, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	v, ok := c.m[key]
+	return v, ok, nil
+}
+
+func (c *memoryCache) Put(_ context.Context, key, _, _, answer string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.m[key] = answer
+	return nil
+}
+
+// firestoreCache persists answers in a Firestore collection.
+type firestoreCache struct {
+	client *firestore.Client
+}
+
+// tutorCacheDoc is the stored document shape.
+type tutorCacheDoc struct {
+	Question  string    `firestore:"question"`
+	Chapter   string    `firestore:"chapter"`
+	Answer    string    `firestore:"answer"`
+	CreatedAt time.Time `firestore:"createdAt,serverTimestamp"`
+}
+
+func (c *firestoreCache) Get(ctx context.Context, key string) (string, bool, error) {
+	doc, err := c.client.Collection(tutorCacheCollection).Doc(key).Get(ctx)
+	if err != nil {
+		if status.Code(err) == codes.NotFound {
+			return "", false, nil
+		}
+		return "", false, fmt.Errorf("firestore get: %w", err)
+	}
+	var d tutorCacheDoc
+	if err := doc.DataTo(&d); err != nil {
+		return "", false, fmt.Errorf("firestore decode: %w", err)
+	}
+	return d.Answer, true, nil
+}
+
+func (c *firestoreCache) Put(ctx context.Context, key, question, chapter, answer string) error {
+	_, err := c.client.Collection(tutorCacheCollection).Doc(key).Set(ctx, tutorCacheDoc{
+		Question: question,
+		Chapter:  chapter,
+		Answer:   answer,
+	})
+	if err != nil {
+		return fmt.Errorf("firestore set: %w", err)
+	}
+	return nil
+}
+
+// NewTutorCache returns a Firestore-backed cache when GOOGLE_CLOUD_PROJECT is set
+// and a client can be created; otherwise it returns an in-memory cache. The
+// second return value names the active backend ("firestore" or "memory") so the
+// caller can log it. Reuses the same ADC/project configuration as the Anthropic
+// key lookup.
+func NewTutorCache(ctx context.Context) (TutorCache, string) {
+	project := os.Getenv(tutorProjectEnv)
+	if project != "" {
+		if client, err := firestore.NewClient(ctx, project); err == nil {
+			return &firestoreCache{client: client}, "firestore"
+		}
+	}
+	return newMemoryCache(), "memory"
+}

--- a/clients/tutorcache_test.go
+++ b/clients/tutorcache_test.go
@@ -1,0 +1,51 @@
+package clients_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/opendroid/the-gpl/clients"
+)
+
+// TestTutorCacheKey_Normalization verifies that trivial formatting differences
+// collapse to the same key, while different chapters (or text) do not.
+func TestTutorCacheKey_Normalization(t *testing.T) {
+	base := clients.TutorCacheKey("What is a goroutine?", "1")
+
+	// Case and whitespace differences normalize to the same key.
+	assert.Equal(t, base, clients.TutorCacheKey("  what   is a   GOROUTINE?  ", "1"))
+
+	// A different chapter must produce a different key.
+	assert.NotEqual(t, base, clients.TutorCacheKey("What is a goroutine?", "2"))
+
+	// Different text must produce a different key.
+	assert.NotEqual(t, base, clients.TutorCacheKey("What is a channel?", "1"))
+}
+
+// TestMemoryCache_GetPut verifies miss → put → hit.
+func TestMemoryCache_GetPut(t *testing.T) {
+	ctx := context.Background()
+	c := clients.NewMemoryTutorCache()
+	key := clients.TutorCacheKey("What is a mutex?", "9")
+
+	_, found, err := c.Get(ctx, key)
+	assert.NoError(t, err)
+	assert.False(t, found)
+
+	assert.NoError(t, c.Put(ctx, key, "What is a mutex?", "9", "A mutex guards shared state."))
+
+	answer, found, err := c.Get(ctx, key)
+	assert.NoError(t, err)
+	assert.True(t, found)
+	assert.Equal(t, "A mutex guards shared state.", answer)
+}
+
+// TestNewTutorCache_DefaultsToMemory verifies that without GOOGLE_CLOUD_PROJECT
+// the cache falls back to the in-memory backend.
+func TestNewTutorCache_DefaultsToMemory(t *testing.T) {
+	t.Setenv("GOOGLE_CLOUD_PROJECT", "")
+	_, backend := clients.NewTutorCache(context.Background())
+	assert.Equal(t, "memory", backend)
+}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.26.0
 
 require (
 	cloud.google.com/go/dialogflow v1.85.0
+	cloud.google.com/go/firestore v1.24.0
 	cloud.google.com/go/secretmanager v1.21.0
 	cloud.google.com/go/speech v1.36.0
 	github.com/anthropics/anthropic-sdk-go v1.58.0
@@ -13,6 +14,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/net v0.57.0
 	google.golang.org/api v0.289.0
+	google.golang.org/grpc v1.82.1
 )
 
 require (
@@ -58,7 +60,6 @@ require (
 	google.golang.org/genproto v0.0.0-20260720171339-e059f2f05d78 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260720171339-e059f2f05d78 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260720171339-e059f2f05d78 // indirect
-	google.golang.org/grpc v1.82.1 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ cloud.google.com/go/compute/metadata v0.9.0 h1:pDUj4QMoPejqq20dK0Pg2N4yG9zIkYGdB
 cloud.google.com/go/compute/metadata v0.9.0/go.mod h1:E0bWwX5wTnLPedCKqk3pJmVgCBSM6qQI1yTBdEb3C10=
 cloud.google.com/go/dialogflow v1.85.0 h1:BySuYr/crqFSP9iFFp36LJ1t49qpn00oqtreGyhD3yA=
 cloud.google.com/go/dialogflow v1.85.0/go.mod h1:OU8Lj1aw5Vr2hl9ifW+vsKnc2b4iJH+41U7nZ4whg3U=
+cloud.google.com/go/firestore v1.24.0 h1:x0Z3hrgjYgo2wI9whuBRQcNc2hYwzZDQy/7pkUXbXcs=
+cloud.google.com/go/firestore v1.24.0/go.mod h1:5aojyjN4olKUnBZDCRWwM+NsdrrCX3t1qfyERZGOonM=
 cloud.google.com/go/iam v1.12.0 h1:Aki3bX9aHUDKPHfnRJfDcTdVedvy6quGBQcTqx3DRXk=
 cloud.google.com/go/iam v1.12.0/go.mod h1:FEZ4lXpADAC2AIpQY7LANNjjwyQ2jK439CI2VaD+sLY=
 cloud.google.com/go/longrunning v1.2.0 h1:WjYH3YHBGCxGJP9M4dWGHBfXr/cFIjMkNgWcJj7/iMM=

--- a/public/css/redesign/tutor.css
+++ b/public/css/redesign/tutor.css
@@ -73,3 +73,4 @@
 }
 .chat-form select:focus { outline: none; border-color: var(--accent); }
 #sendBtn:disabled { background: var(--faint); cursor: not-allowed; }
+.cached-badge { font-family: var(--mono); font-size: 11px; color: var(--faint); }

--- a/public/templates/ask.gohtml
+++ b/public/templates/ask.gohtml
@@ -19,12 +19,8 @@
         </div>
 
         <form class="chat-form" id="chatForm" onsubmit="return sendQuestion()">
-            <textarea id="questionInput" rows="2" placeholder="e.g. When should I use a buffered channel? Paste code, error output, or a full question — there's room." autocomplete="off" required></textarea>
-            <div class="chat-chips">
-                <button type="button" class="chip" data-q="What's the difference between a buffered and an unbuffered channel?" onclick="fillPrompt(this)">buffered vs unbuffered</button>
-                <button type="button" class="chip" data-q="When should I use a sync.Mutex instead of a channel?" onclick="fillPrompt(this)">when to use a mutex</button>
-                <button type="button" class="chip" data-q="How does the select statement work in Go?" onclick="fillPrompt(this)">select statement</button>
-            </div>
+            <textarea id="questionInput" rows="12" placeholder="Ask anything about Go — or pick a suggestion below." autocomplete="off" required></textarea>
+            <div class="chat-chips" id="chatChips"></div>
             <div class="chat-actions">
                 <select id="chapterSelect">
                     <option value="">No chapter</option>
@@ -44,11 +40,74 @@
 </main>
 {{template "footer"}}
 <script>
+// Chapter-based suggested questions, injected by askPageHandler (static, trusted).
+var CHAPTER_PROMPTS = {{ .PromptsJSON }};
+
+// Every prompt's full question, used to tell a still-default textbox from one the
+// user has edited (so a chapter change never clobbers the user's own text).
+var KNOWN_DEFAULTS = (function() {
+    var s = {};
+    Object.keys(CHAPTER_PROMPTS).forEach(function(k) {
+        (CHAPTER_PROMPTS[k] || []).forEach(function(p) { s[p.q] = true; });
+    });
+    return s;
+})();
+
+function promptsFor(chapter) {
+    return CHAPTER_PROMPTS[chapter] || CHAPTER_PROMPTS[''] || [];
+}
+
+function defaultTextFor(chapter) {
+    var list = promptsFor(chapter);
+    return list.length ? list[0].q : '';
+}
+
+function isReplaceable(value) {
+    var v = value.trim();
+    return v === '' || KNOWN_DEFAULTS[v] === true;
+}
+
+function renderChips(chapter) {
+    var wrap = document.getElementById('chatChips');
+    wrap.innerHTML = '';
+    promptsFor(chapter).forEach(function(p) {
+        var b = document.createElement('button');
+        b.type = 'button';
+        b.className = 'chip';
+        b.textContent = p.label;
+        b.dataset.q = p.q;
+        b.addEventListener('click', function() { fillPrompt(b); });
+        wrap.appendChild(b);
+    });
+}
+
 function fillPrompt(btn) {
     var input = document.getElementById('questionInput');
     input.value = btn.dataset.q;
-    input.focus();
+    input.focus(); // focus handler selects the (default) text so it's easy to replace
 }
+
+// Wire up chapter-driven suggestions + a real, selectable default question.
+(function() {
+    var sel = document.getElementById('chapterSelect');
+    var input = document.getElementById('questionInput');
+    renderChips(sel.value);
+    input.value = defaultTextFor(sel.value);
+    sel.addEventListener('change', function() {
+        renderChips(sel.value);
+        if (isReplaceable(input.value)) {
+            input.value = defaultTextFor(sel.value);
+        }
+    });
+    // Select the default text on focus so the first keystroke replaces it; once
+    // the user has typed their own question, focusing leaves it alone.
+    input.addEventListener('focus', function() {
+        if (isReplaceable(input.value)) {
+            input.select();
+        }
+    });
+})();
+
 function parseMarkdown(text) {
     text = text.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
     text = text.replace(/```[^\n]*\n([\s\S]*?)```/g, '<pre><code>$1</code></pre>');
@@ -106,7 +165,8 @@ function sendQuestion() {
         .then(function(data){
             var tutorDiv = document.createElement('div');
             tutorDiv.className = 'chat-msg tutor';
-            tutorDiv.innerHTML = '<strong>Tutor:</strong> ' + parseMarkdown(data.answer || data.error || 'No response.');
+            var cachedTag = data.cached ? ' <span class="cached-badge">· cached</span>' : '';
+            tutorDiv.innerHTML = '<strong>Tutor:</strong> ' + parseMarkdown(data.answer || data.error || 'No response.') + cachedTag;
             box.appendChild(tutorDiv);
             box.scrollTop = box.scrollHeight;
         })

--- a/public/templates/ask.gohtml
+++ b/public/templates/ask.gohtml
@@ -19,7 +19,7 @@
         </div>
 
         <form class="chat-form" id="chatForm" onsubmit="return sendQuestion()">
-            <textarea id="questionInput" rows="12" placeholder="Ask anything about Go — or pick a suggestion below." autocomplete="off" required></textarea>
+            <textarea id="questionInput" rows="2" placeholder="Ask anything about Go — or pick a suggestion below." autocomplete="off" required></textarea>
             <div class="chat-chips" id="chatChips"></div>
             <div class="chat-actions">
                 <select id="chapterSelect">

--- a/serve/web/ask_test.go
+++ b/serve/web/ask_test.go
@@ -1,0 +1,93 @@
+package web
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/opendroid/the-gpl/clients"
+	clientsMock "github.com/opendroid/the-gpl/mocks/clients"
+)
+
+// withTutorState swaps the package-level gateway + tutorCache for a test and
+// restores them on cleanup.
+func withTutorState(t *testing.T, gw *clients.Gateway, cache clients.TutorCache) {
+	t.Helper()
+	origGw, origCache := gateway, tutorCache
+	gateway, tutorCache = gw, cache
+	t.Cleanup(func() { gateway, tutorCache = origGw, origCache })
+}
+
+// askResp is the decoded /ask body used in tests.
+type askResp struct {
+	Answer string `json:"answer"`
+	Error  string `json:"error"`
+	Cached bool   `json:"cached"`
+}
+
+// Test_askHandler_cacheHit: a pre-seeded exact match is served from cache and the
+// model is never called.
+func Test_askHandler_cacheHit(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockClient := clientsMock.NewMockAnthropicClient(ctrl)
+	mockClient.EXPECT().Ask(gomock.Any(), gomock.Any(), gomock.Any()).Times(0) // must not be called
+
+	cache := clients.NewMemoryTutorCache()
+	key := clients.TutorCacheKey("What is a goroutine?", "1")
+	_ = cache.Put(context.Background(), key, "What is a goroutine?", "1", "A goroutine is a lightweight thread.")
+	withTutorState(t, clients.NewGateway(nil, mockClient), cache)
+
+	rr := serve(t, askHandler, "/ask?q=What+is+a+goroutine%3F&chapter=1")
+	assert.Equal(t, 200, rr.Code)
+
+	var resp askResp
+	assert.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	assert.Equal(t, "A goroutine is a lightweight thread.", resp.Answer)
+	assert.True(t, resp.Cached)
+}
+
+// Test_askHandler_missStores: a miss calls the model once, returns cached:false,
+// and stores the answer under the normalized key.
+func Test_askHandler_missStores(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockClient := clientsMock.NewMockAnthropicClient(ctrl)
+	mockClient.EXPECT().
+		Ask(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return("Channels let goroutines communicate.", nil).
+		Times(1)
+
+	cache := clients.NewMemoryTutorCache()
+	withTutorState(t, clients.NewGateway(nil, mockClient), cache)
+
+	rr := serve(t, askHandler, "/ask?q=What+is+a+channel%3F&chapter=8")
+	assert.Equal(t, 200, rr.Code)
+
+	var resp askResp
+	assert.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	assert.Equal(t, "Channels let goroutines communicate.", resp.Answer)
+	assert.False(t, resp.Cached)
+
+	// Stored under the normalized key for next time.
+	got, found, err := cache.Get(context.Background(), clients.TutorCacheKey("What is a channel?", "8"))
+	assert.NoError(t, err)
+	assert.True(t, found)
+	assert.Equal(t, "Channels let goroutines communicate.", got)
+}
+
+// Test_askHandler_missingQuery: no q → 400 with an error body.
+func Test_askHandler_missingQuery(t *testing.T) {
+	withTutorState(t, gateway, clients.NewMemoryTutorCache())
+	rr := serve(t, askHandler, "/ask")
+	assert.Equal(t, 400, rr.Code)
+
+	var resp askResp
+	assert.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	assert.NotEmpty(t, resp.Error)
+}

--- a/serve/web/pagedata.go
+++ b/serve/web/pagedata.go
@@ -1,5 +1,7 @@
 package web
 
+import "html/template"
+
 // Active defines current active page, one of enums
 type Active string
 
@@ -145,9 +147,11 @@ type ChaptersPageData struct {
 	Chapters []ChapterEntry
 }
 
-// AskPageData is the template data for /ask-page.
+// AskPageData is the template data for /ask-page. PromptsJSON is the marshaled
+// chapterPrompts map, injected into the page for the chapter-based suggestions.
 type AskPageData struct {
-	Active string
+	Active      string
+	PromptsJSON template.JS
 }
 
 // Template names and Page headings

--- a/serve/web/tutordata.go
+++ b/serve/web/tutordata.go
@@ -1,0 +1,89 @@
+package web
+
+import "fmt"
+
+// bookChapters is the single source of truth for the nine book chapters. It is
+// rendered on /chapters (chaptersHandler) and reused by chapterContext to give
+// the AI tutor chapter-aware context.
+var bookChapters = []ChapterEntry{
+	{1, "Tutorial", "Goroutines, channels, CLI utilities, the Lissajous GIF, a Dialogflow bot, and Speech-to-Text.", chapterURL(1)},
+	{2, "Program Structure", "Bit counting via three strategies, temperature-conversion types, and package-level variables.", chapterURL(2)},
+	{3, "Basic Data Types", "Mandelbrot PNG, 3-D surface plots as SVG, and string utilities.", chapterURL(3)},
+	{4, "Composite Types", "JSON marshalling, HTML templating, and GitHub issue search.", chapterURL(4)},
+	{5, "Functions", "HTML traversal, a web crawler, topological sort, variadic max/min, generic MaxOf/MinOf.", chapterURL(5)},
+	{6, "Methods", "An IntSet bit-vector: Union, Intersect, Difference, SymmetricDifference.", chapterURL(6)},
+	{7, "Interfaces", "Writer implementations, CountWriter, BroadcastWriters, and a temperature flag.", chapterURL(7)},
+	{8, "Goroutines & Channels", "TCP services (clock, reverb, chat, FTP), concurrent du, and web search with context.", chapterURL(8)},
+	{9, "Concurrency & Shared Variables", "sync.Mutex SafeBank, sync.RWMutex RWBank, sync.Once Icon, and a Memo cache.", chapterURL(9)},
+}
+
+// Prompt is one suggested tutor question. Label is the short chip text; Q is the
+// full question prefilled into the textarea. JSON tags feed the front-end.
+type Prompt struct {
+	Label string `json:"label"`
+	Q     string `json:"q"`
+}
+
+// chapterPrompts maps a chapter <select> value ("" = no chapter) to its suggested
+// questions. Keys match exactly the options rendered in ask.gohtml.
+var chapterPrompts = map[string][]Prompt{
+	"": {
+		{"buffered vs unbuffered", "What's the difference between a buffered and an unbuffered channel?"},
+		{"when to use a mutex", "When should I use a sync.Mutex instead of a channel?"},
+		{"select statement", "How does the select statement work in Go?"},
+	},
+	"1": {
+		{"goroutines", "What is a goroutine and how do I start one?"},
+		{"the Lissajous demo", "How does the Lissajous GIF program generate its animation?"},
+		{"reading stdin", "How do I read input line by line from standard input in Go?"},
+	},
+	"2": {
+		{"iota & constants", "How does iota work when declaring a set of constants?"},
+		{"bit counting", "What are the different ways to count the set bits in an integer?"},
+		{"named types", "Why define a named type like Celsius instead of using a plain float64?"},
+	},
+	"3": {
+		{"rune vs byte", "What's the difference between a rune and a byte in Go?"},
+		{"complex numbers", "How do I work with complex numbers, like in the Mandelbrot demo?"},
+		{"floating point", "How do floating-point precision issues show up in Go?"},
+	},
+	"5": {
+		{"variadic functions", "How do variadic functions work in Go?"},
+		{"closures", "What is a closure and when is it useful?"},
+		{"defer", "How does defer work and when do deferred calls run?"},
+	},
+	"6": {
+		{"pointer vs value receiver", "When should a method use a pointer receiver instead of a value receiver?"},
+		{"method sets", "What is a method set and how does it affect interface satisfaction?"},
+		{"IntSet bit-vector", "How does the IntSet bit-vector represent a set of integers?"},
+	},
+	"7": {
+		{"interface satisfaction", "How does a type satisfy an interface in Go?"},
+		{"empty interface", "What is the empty interface and when should I use it?"},
+		{"type assertions", "How do type assertions and type switches work?"},
+	},
+	"8": {
+		{"channel directions", "What are send-only and receive-only channel types for?"},
+		{"pipelines", "How do I build a pipeline of goroutines connected by channels?"},
+		{"context cancellation", "How do I cancel running goroutines with a context?"},
+	},
+	"9": {
+		{"data races", "What is a data race and how do I detect one in Go?"},
+		{"Mutex vs RWMutex", "When should I use sync.RWMutex instead of sync.Mutex?"},
+		{"sync.Once", "What is sync.Once used for?"},
+	},
+}
+
+// chapterContext returns a one-line context string for the AI tutor describing
+// the selected chapter, or "" when no (or an unknown) chapter is selected.
+func chapterContext(chapter string) string {
+	if chapter == "" {
+		return ""
+	}
+	for _, c := range bookChapters {
+		if fmt.Sprintf("%d", c.Number) == chapter {
+			return fmt.Sprintf("This question relates to Chapter %d — %s: %s", c.Number, c.Title, c.Description)
+		}
+	}
+	return ""
+}

--- a/serve/web/tutordata_test.go
+++ b/serve/web/tutordata_test.go
@@ -1,0 +1,41 @@
+package web
+
+import (
+	"strings"
+	"testing"
+)
+
+// selectOptions are the chapter <select> values rendered in ask.gohtml.
+var selectOptions = []string{"", "1", "2", "3", "5", "6", "7", "8", "9"}
+
+// Test_chapterPrompts_coverEverySelectOption verifies every dropdown option has
+// at least one suggested question with non-empty label and question.
+func Test_chapterPrompts_coverEverySelectOption(t *testing.T) {
+	for _, opt := range selectOptions {
+		prompts, ok := chapterPrompts[opt]
+		if !ok || len(prompts) == 0 {
+			t.Errorf("chapterPrompts missing entries for option %q", opt)
+			continue
+		}
+		for i, p := range prompts {
+			if strings.TrimSpace(p.Label) == "" || strings.TrimSpace(p.Q) == "" {
+				t.Errorf("option %q prompt %d has empty Label or Q", opt, i)
+			}
+		}
+	}
+}
+
+// Test_chapterContext verifies chapter context is produced for a known chapter
+// and empty for no chapter.
+func Test_chapterContext(t *testing.T) {
+	if got := chapterContext(""); got != "" {
+		t.Errorf("chapterContext(\"\") = %q, want empty", got)
+	}
+	got := chapterContext("5")
+	if got == "" || !strings.Contains(got, "Chapter 5") || !strings.Contains(got, "Functions") {
+		t.Errorf("chapterContext(\"5\") = %q, want it to mention Chapter 5 / Functions", got)
+	}
+	if got := chapterContext("99"); got != "" {
+		t.Errorf("chapterContext(\"99\") = %q, want empty for unknown chapter", got)
+	}
+}

--- a/serve/web/web.go
+++ b/serve/web/web.go
@@ -7,6 +7,7 @@
 package web
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -27,6 +28,11 @@ var counter int
 // gateway is the package-level Gateway used by askHandler. Tests can
 // substitute gateway.Anthropic with a mock.
 var gateway *clients.Gateway
+
+// tutorCache is the package-level answer cache used by askHandler. It is lazily
+// created on first use (Firestore in prod, in-memory otherwise). Tests can
+// substitute an in-memory cache.
+var tutorCache clients.TutorCache
 
 // handlers stores URLS to HandlerFunc
 var handlers = map[string]func(http.ResponseWriter, *http.Request){
@@ -133,36 +139,69 @@ func testHandler(w http.ResponseWriter, _ *http.Request) {
 	_, _ = fmt.Fprintln(w, "Hello from server")
 }
 
-// askHandler answers a Go tutor question via Claude.
+// askResponse is the JSON body returned by /ask.
+type askResponse struct {
+	Answer string `json:"answer,omitempty"`
+	Error  string `json:"error,omitempty"`
+	Cached bool   `json:"cached"`
+}
+
+// askHandler answers a Go tutor question via Claude. Exact-match repeats
+// (same normalized question + chapter) are served from the tutor cache without
+// calling the model. The selected chapter is passed to the model as context.
 //
 // GET /ask?q=<question>&chapter=<N>
-// Returns JSON: {"answer": "..."}  or  {"error": "..."}
+// Returns JSON: {"answer": "...", "cached": bool}  or  {"error": "..."}
 func askHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
 	q := r.URL.Query().Get("q")
 	if q == "" {
-		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusBadRequest)
-		_ = json.NewEncoder(w).Encode(map[string]string{"error": "q parameter is required"})
+		_ = json.NewEncoder(w).Encode(askResponse{Error: "q parameter is required"})
 		return
 	}
+	chapter := r.URL.Query().Get("chapter")
+
+	// Lazily create the cache: Firestore when GOOGLE_CLOUD_PROJECT is set,
+	// in-memory otherwise. context.Background so the client outlives the request.
+	if tutorCache == nil {
+		c, backend := clients.NewTutorCache(context.Background())
+		tutorCache = c
+		slog.Info("askHandler: tutor cache initialised", "backend", backend)
+	}
+
+	// Exact-match cache hit → serve without calling the model.
+	key := clients.TutorCacheKey(q, chapter)
+	if answer, found, err := tutorCache.Get(r.Context(), key); err != nil {
+		slog.Error("askHandler: cache get", "err", err) // treat as a miss
+	} else if found {
+		slog.Info("askHandler: cache hit", "chapter", chapter)
+		_ = json.NewEncoder(w).Encode(askResponse{Answer: answer, Cached: true})
+		return
+	}
+
+	// Miss → ensure a gateway, then ask the model with chapter context.
 	if gateway == nil || gateway.Anthropic == nil {
 		client, err := clients.NewAnthropicClient(r.Context())
 		if err != nil {
 			slog.Error("askHandler: tutor client init error", "err", err)
-			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusInternalServerError)
-			_ = json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+			_ = json.NewEncoder(w).Encode(askResponse{Error: err.Error()})
 			return
 		}
 		gateway = clients.NewGateway(nil, client)
 	}
-	answer, err := gateway.Ask(r.Context(), q, "")
-	w.Header().Set("Content-Type", "application/json")
+	answer, err := gateway.Ask(r.Context(), q, chapterContext(chapter))
 	if err != nil {
 		slog.Error("askHandler: tutor error", "err", err)
 		w.WriteHeader(http.StatusInternalServerError)
-		_ = json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+		_ = json.NewEncoder(w).Encode(askResponse{Error: err.Error()})
 		return
 	}
-	_ = json.NewEncoder(w).Encode(map[string]string{"answer": answer})
+
+	// Best-effort store; a cache failure must not fail the response.
+	if err := tutorCache.Put(r.Context(), key, q, chapter, answer); err != nil {
+		slog.Error("askHandler: cache put", "err", err)
+	}
+	_ = json.NewEncoder(w).Encode(askResponse{Answer: answer, Cached: false})
 }

--- a/serve/web/webtpl.go
+++ b/serve/web/webtpl.go
@@ -2,6 +2,7 @@ package web
 
 import (
 	"compress/gzip"
+	"encoding/json"
 	"fmt"
 	"html/template"
 	"io"
@@ -177,28 +178,25 @@ func chapterURL(n int) string {
 func chaptersHandler(w http.ResponseWriter, _ *http.Request) {
 	slog.Info("chaptersHandler.")
 	data := ChaptersPageData{
-		Active: Chapters.String(),
-		Chapters: []ChapterEntry{
-			{1, "Tutorial", "Goroutines, channels, CLI utilities, the Lissajous GIF, a Dialogflow bot, and Speech-to-Text.", chapterURL(1)},
-			{2, "Program Structure", "Bit counting via three strategies, temperature-conversion types, and package-level variables.", chapterURL(2)},
-			{3, "Basic Data Types", "Mandelbrot PNG, 3-D surface plots as SVG, and string utilities.", chapterURL(3)},
-			{4, "Composite Types", "JSON marshalling, HTML templating, and GitHub issue search.", chapterURL(4)},
-			{5, "Functions", "HTML traversal, a web crawler, topological sort, variadic max/min, generic MaxOf/MinOf.", chapterURL(5)},
-			{6, "Methods", "An IntSet bit-vector: Union, Intersect, Difference, SymmetricDifference.", chapterURL(6)},
-			{7, "Interfaces", "Writer implementations, CountWriter, BroadcastWriters, and a temperature flag.", chapterURL(7)},
-			{8, "Goroutines & Channels", "TCP services (clock, reverb, chat, FTP), concurrent du, and web search with context.", chapterURL(8)},
-			{9, "Concurrency & Shared Variables", "sync.Mutex SafeBank, sync.RWMutex RWBank, sync.Once Icon, and a Memo cache.", chapterURL(9)},
-		},
+		Active:   Chapters.String(),
+		Chapters: bookChapters,
 	}
 	if err := templates.ExecuteTemplate(w, ChaptersPage, &data); err != nil {
 		slog.Error("chaptersHandler", "err", err)
 	}
 }
 
-// askPageHandler renders the AI tutor chat UI at /ask-page.
+// askPageHandler renders the AI tutor chat UI at /ask-page, injecting the
+// chapter-based suggested questions as JSON.
 func askPageHandler(w http.ResponseWriter, _ *http.Request) {
 	slog.Info("askPageHandler.")
-	if err := templates.ExecuteTemplate(w, AskPage, &AskPageData{Active: Ask.String()}); err != nil {
+	promptsJSON, err := json.Marshal(chapterPrompts)
+	if err != nil {
+		slog.Error("askPageHandler: marshal prompts", "err", err)
+		promptsJSON = []byte("{}")
+	}
+	data := AskPageData{Active: Ask.String(), PromptsJSON: template.JS(promptsJSON)}
+	if err := templates.ExecuteTemplate(w, AskPage, &data); err != nil {
 		slog.Error("askPageHandler", "err", err)
 	}
 }


### PR DESCRIPTION
Closes #65.

Improves `/ask-page` and the `/ask` endpoint.

## What changed

**Chapter-driven suggestions.** `chapterPrompts` (in the new `serve/web/tutordata.go`) maps every chapter dropdown option to three suggested questions. `askPageHandler` marshals it into `AskPageData.PromptsJSON` (`template.JS`) and the page renders the chips from it, so changing the chapter finally does something.

**Chapter-aware answers.** `askHandler` was passing an empty chapter context to `Gateway.Ask` even though the gateway already supported it. It now passes `chapterContext(chapter)`, a one-line description built from the chapter list.

**Selectable, editable default.** The textarea starts with the selected chapter's first suggested question as real (editable) text rather than a grey placeholder, and selects it on focus so the first keystroke replaces it. Changing the chapter only rewrites the text when it is still empty or still one of the known defaults — text the user typed is never clobbered.

**Exact-match answer cache.** `clients/tutorcache.go` adds a `TutorCache` interface keyed by `sha256(chapter + "\n" + normalized question)` (whitespace collapsed, lower-cased). A hit is returned without calling the paid API, and `/ask` responses now carry a `cached` flag which the page renders as a `· cached` badge. Cache errors are non-fatal: a failed `Get` is treated as a miss, a failed `Put` is logged and the answer still returned.

**Persistence.** The cache is Firestore-backed when `GOOGLE_CLOUD_PROJECT` is set (reusing the existing ADC config), with an in-memory fallback otherwise. The active backend is logged on first use. Adds `cloud.google.com/go/firestore`.

**Refactor.** The nine-chapter list moves out of `chaptersHandler` into a single `bookChapters` var reused by both `/chapters` and `chapterContext`.

## Tests

Eight new unit tests: cache key normalization, in-memory miss→put→hit, the memory fallback when `GOOGLE_CLOUD_PROJECT` is unset, prompt coverage for every chapter dropdown option, `chapterContext` for known/unknown/empty chapters, and `askHandler`'s cache-hit (model never called), miss-stores, and missing-`q` paths.

```
go build ./...                              clean
go vet ./...                                clean
gofmt -l .                                  clean
go test ./clients/... ./serve/web/...       ok
```

Locally `go test ./...` also shows failures in `chapter1/channels`, `chapter4`, and `chapter5` — those tests reach github.com and google.com and are blocked by the dev sandbox's proxy. They are untouched by this change and pass on the CI runner.

## Manual verification

Ran the server and drove `/ask-page` in a headless browser: chips and default text track the chapter (no chapter → buffered vs unbuffered, 9 → data races, 3 → rune vs byte); focus selects the default; typing replaces it and a subsequent chapter change leaves the typed text alone; chip clicks fill the full question. Hitting `/ask` without an API key still returns the original 500 JSON shape, and the server logged `askHandler: tutor cache initialised backend=memory`.