### PR TITLE
Tutor page: stop password managers autofilling the question box

### DIFF
--- a/public/templates/ask.gohtml
+++ b/public/templates/ask.gohtml
@@ -18,8 +18,11 @@
             <div class="chat-msg tutor">Hello! I'm your Go tutor. Ask me anything about Go or the book chapters.</div>
         </div>
 
-        <form class="chat-form" id="chatForm" onsubmit="return sendQuestion()">
-            <textarea id="questionInput" rows="2" placeholder="Ask anything about Go — or pick a suggestion below." autocomplete="off" required></textarea>
+        <!-- autocomplete/data-*ignore attributes keep password managers (iCloud
+             Passwords, 1Password, LastPass, Bitwarden, Dashlane) from offering to
+             autofill this free-text question box. -->
+        <form class="chat-form" id="chatForm" onsubmit="return sendQuestion()" autocomplete="off" data-form-type="other">
+            <textarea id="questionInput" rows="2" placeholder="Ask anything about Go — or pick a suggestion below." autocomplete="off" data-form-type="other" data-1p-ignore data-lpignore="true" data-bwignore required></textarea>
             <div class="chat-chips" id="chatChips"></div>
             <div class="chat-actions">
                 <select id="chapterSelect">


### PR DESCRIPTION
Closes #67.

Focusing the question textarea on `/ask-page` popped the iCloud Passwords helper over the suggestion chips.

`autocomplete="off"` was already on the textarea and is not enough on its own — password managers largely ignore it (sites abused it to block managers on real login forms) and fall back to heuristics on the containing `<form>`. `#chatForm` reads as credential-shaped to those heuristics: one free-text field plus a submit button.

## Change

Attribute-only, in `public/templates/ask.gohtml`. The form and the field are now marked as non-credential using the attributes each vendor actually honors:

- `autocomplete="off"` on the `<form>` as well as the field
- `data-form-type="other"` (Dashlane)
- `data-1p-ignore` (1Password)
- `data-lpignore="true"` (LastPass)
- `data-bwignore` (Bitwarden)

The `<form>` wrapper stays, so `required` validation and Enter-to-submit still work, and `sendQuestion()` is untouched.

## Verification

```
go build ./...                              clean
go vet ./...                                clean
gofmt -l .                                  clean
go test ./clients/... ./serve/web/...       ok
```

Re-ran the headless browser check against a live server to confirm no regression: chips and default text still track the chapter, focus still selects the default, typed text still survives a chapter change, and chip clicks still fill the full question.

**The actual popup could not be verified here.** It comes from a macOS system integration / browser extension, not from the page, so neither CI nor a headless Chromium in this sandbox can reproduce it. This needs a manual check in Safari on a Mac after deploy.

If the iCloud popup survives these attributes, the fallback is to drop the `<form>` wrapper entirely and wire submit + validation by hand in JS, which removes the heuristic's trigger rather than asking it politely. That is a bigger change and not worth making blind.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q1vR7mj67QeCDd1U5SgyHn)_