### PR TITLE
Tutor cache: probe Firestore before reporting it as the backend

### DIFF
--- a/clients/tutorcache.go
+++ b/clients/tutorcache.go
@@ -4,13 +4,16 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"strings"
 	"sync"
 	"time"
 
 	"cloud.google.com/go/firestore"
+	"google.golang.org/api/iterator"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -29,6 +32,9 @@ type TutorCache interface {
 const (
 	tutorCacheCollection = "tutor_cache"
 	tutorProjectEnv      = "GOOGLE_CLOUD_PROJECT"
+	// tutorProbeTimeout bounds the startup reachability check so a slow or
+	// unresponsive Firestore cannot stall the first /ask request.
+	tutorProbeTimeout = 5 * time.Second
 )
 
 // TutorCacheKey builds a stable exact-match key from a question and chapter.
@@ -109,17 +115,46 @@ func (c *firestoreCache) Put(ctx context.Context, key, question, chapter, answer
 	return nil
 }
 
+// probeFirestore checks that the database is actually reachable and readable.
+//
+// firestore.NewClient only resolves credentials — it never contacts the server —
+// so a client is returned successfully even when the project has no Firestore
+// database at all. Listing root collections is a cheap read that distinguishes
+// the cases: an empty-but-healthy database ends the iterator immediately, while
+// a missing database or a service account without access returns an error.
+func probeFirestore(ctx context.Context, client *firestore.Client) error {
+	ctx, cancel := context.WithTimeout(ctx, tutorProbeTimeout)
+	defer cancel()
+	if _, err := client.Collections(ctx).Next(); err != nil && !errors.Is(err, iterator.Done) {
+		return fmt.Errorf("firestore probe: %w", err)
+	}
+	return nil
+}
+
 // NewTutorCache returns a Firestore-backed cache when GOOGLE_CLOUD_PROJECT is set
-// and a client can be created; otherwise it returns an in-memory cache. The
+// and the database is reachable; otherwise it returns an in-memory cache. The
 // second return value names the active backend ("firestore" or "memory") so the
 // caller can log it. Reuses the same ADC/project configuration as the Anthropic
 // key lookup.
+//
+// The backend is probed before being reported, so "firestore" means answers are
+// really being persisted. Without the probe an unreachable database degrades
+// silently: every Get fails and is treated as a miss, every Put fails, and the
+// cache never holds anything while still reporting itself as Firestore-backed.
 func NewTutorCache(ctx context.Context) (TutorCache, string) {
 	project := os.Getenv(tutorProjectEnv)
-	if project != "" {
-		if client, err := firestore.NewClient(ctx, project); err == nil {
-			return &firestoreCache{client: client}, "firestore"
-		}
+	if project == "" {
+		return newMemoryCache(), "memory"
 	}
-	return newMemoryCache(), "memory"
+	client, err := firestore.NewClient(ctx, project)
+	if err != nil {
+		slog.Warn("tutor cache: firestore client unavailable, falling back to memory", "err", err)
+		return newMemoryCache(), "memory"
+	}
+	if err := probeFirestore(ctx, client); err != nil {
+		slog.Warn("tutor cache: firestore unreachable, falling back to memory", "err", err)
+		_ = client.Close()
+		return newMemoryCache(), "memory"
+	}
+	return &firestoreCache{client: client}, "firestore"
 }

--- a/clients/tutorcache_test.go
+++ b/clients/tutorcache_test.go
@@ -49,3 +49,14 @@ func TestNewTutorCache_DefaultsToMemory(t *testing.T) {
 	_, backend := clients.NewTutorCache(context.Background())
 	assert.Equal(t, "memory", backend)
 }
+
+// TestNewTutorCache_UnreachableFallsBackToMemory verifies that a project with no
+// usable Firestore is reported as "memory" rather than "firestore". Both routes
+// land on the fallback: without ADC the client cannot be built at all, and with
+// ADC the reachability probe fails against a project that does not exist. The
+// probe is bounded by tutorProbeTimeout, so this stays fast either way.
+func TestNewTutorCache_UnreachableFallsBackToMemory(t *testing.T) {
+	t.Setenv("GOOGLE_CLOUD_PROJECT", "the-gpl-no-such-project-8f3a1c")
+	_, backend := clients.NewTutorCache(context.Background())
+	assert.Equal(t, "memory", backend)
+}


### PR DESCRIPTION
Closes #69.

`firestore.NewClient` only resolves credentials — it never contacts the server — so `NewTutorCache` returned the Firestore backend even when the project had no Firestore database. The cache then failed silently: every `Get` failed and was swallowed as a miss by design, every `Put` failed and was logged, nothing was ever cached, and every question hit the paid API while startup logged `backend=firestore`.

That was the live state of `the-gpl-book` from the #66 deploy until the database was created at 05:20Z today. The database now exists, so the outage is over — this PR fixes the reporting defect that let it hide.

## Change

`NewTutorCache` now probes the database before committing to the Firestore backend, and falls back to memory with a warning naming the reason:

```go
client, err := firestore.NewClient(ctx, project)
if err != nil { /* warn, memory */ }
if err := probeFirestore(ctx, client); err != nil { /* warn, close, memory */ }
return &firestoreCache{client: client}, "firestore"
```

The probe lists root collections, bounded by a 5s timeout. That choice is deliberate: a missing *database* and a missing *document* both surface as gRPC `NotFound`, so a document read cannot tell them apart, whereas an empty-but-healthy database simply ends the iterator with `iterator.Done`.

Failure stays non-fatal — an unreachable Firestore degrades to a per-instance memory cache rather than breaking `/ask`.

## Tests

Adds `TestNewTutorCache_UnreachableFallsBackToMemory`: with `GOOGLE_CLOUD_PROJECT` pointed at a nonexistent project, the backend must report `memory`. Both routes land there — without ADC the client cannot be built, and with ADC the probe fails against a project that does not exist — and the probe timeout bounds it either way. Runs in ~10ms here.

```
go build ./...                              clean
go vet ./...                                clean
gofmt -l .                                  clean
go test ./clients/... ./serve/web/...       ok
```

## Verification note

The healthy-Firestore path still cannot be exercised from CI or from my sandbox — neither has GCP credentials, so every automated run takes the fallback branch. Confirming that a real Firestore now reports `backend=firestore` and actually persists has to be done against the deployed service: ask the same question twice and look for the `· cached` badge, and check that `tutor_cache` documents appear.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q1vR7mj67QeCDd1U5SgyHn)_