### PR TITLE
Anthropic key: log which source supplied it

### DIFF
--- a/clients/anthropic_secrets.go
+++ b/clients/anthropic_secrets.go
@@ -3,6 +3,7 @@ package clients
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"os"
 
 	secretmanager "cloud.google.com/go/secretmanager/apiv1"
@@ -15,18 +16,28 @@ const anthropicSecretName = "ANTHROPIC_API_KEY"
 
 // getAnthropicAPIKey returns the Anthropic API key.
 // On Cloud Run it reads from Secret Manager; falls back to the environment for local dev.
+//
+// Which source won is logged (never the key itself). Without that, a broken
+// Secret Manager setup — missing secret, missing secretAccessor role, wrong
+// project — is invisible: the read fails, the environment variable quietly
+// covers for it, and the deployment looks healthy while not using the secret at
+// all.
 func getAnthropicAPIKey(ctx context.Context) (string, error) {
 	project := os.Getenv(anthropicProjectEnv)
 	if project != "" {
 		key, err := readAnthropicSecret(ctx, project)
 		if err == nil {
+			slog.Info("anthropic key: read from Secret Manager", "project", project)
 			return key, nil
 		}
+		slog.Warn("anthropic key: Secret Manager read failed, trying environment",
+			"project", project, "secret", anthropicSecretName, "err", err)
 	}
 	key := os.Getenv(anthropicAPIKeyEnv)
 	if key == "" {
 		return "", fmt.Errorf("%s not set and Secret Manager unavailable", anthropicAPIKeyEnv)
 	}
+	slog.Info("anthropic key: read from environment", "var", anthropicAPIKeyEnv)
 	return key, nil
 }
 

--- a/clients/anthropic_secrets_test.go
+++ b/clients/anthropic_secrets_test.go
@@ -1,0 +1,31 @@
+package clients
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Test_getAnthropicAPIKey_environment verifies the environment fallback is used
+// when no project is configured. An empty project short-circuits the Secret
+// Manager lookup, so this test never touches the network.
+func Test_getAnthropicAPIKey_environment(t *testing.T) {
+	t.Setenv(anthropicProjectEnv, "")
+	t.Setenv(anthropicAPIKeyEnv, "sk-ant-test-key")
+
+	key, err := getAnthropicAPIKey(context.Background())
+	assert.NoError(t, err)
+	assert.Equal(t, "sk-ant-test-key", key)
+}
+
+// Test_getAnthropicAPIKey_missing verifies the error when neither Secret Manager
+// nor the environment can supply a key.
+func Test_getAnthropicAPIKey_missing(t *testing.T) {
+	t.Setenv(anthropicProjectEnv, "")
+	t.Setenv(anthropicAPIKeyEnv, "")
+
+	_, err := getAnthropicAPIKey(context.Background())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), anthropicAPIKeyEnv)
+}


### PR DESCRIPTION
Closes #71.

`getAnthropicAPIKey` tried Secret Manager and discarded the error, so every way that path can break — secret absent, `secretAccessor` not granted, wrong project, API disabled — looked identical to it working: the environment variable covered for it and `/ask` answered normally.

That was the real state of `the-gpl-book`. The runtime service account had no `roles/secretmanager.secretAccessor` binding until today, so the service was running on the environment-variable fallback while appearing to use Secret Manager. Nothing in the logs said so, and the failure would only have surfaced at the worst moment — when the environment variable was removed on the assumption the secret was in use.

Same shape as #69, where the cache reported `backend=firestore` while Firestore was unusable.

## Change

Log the source rather than leaving it to inference:

- Secret Manager hit → `Info` naming the project
- Secret Manager failure → `Warn` with project, secret name, and error, then try the environment
- environment hit → `Info` naming the variable

The key value is never logged. Resolution order and the returned error are unchanged — this is observability only, no behavior change.

## Tests

Adds `Test_getAnthropicAPIKey_environment` and `Test_getAnthropicAPIKey_missing`. Both set an empty project, which short-circuits the Secret Manager lookup, so neither touches the network.

```
go build ./...                              clean
go vet ./...                                clean
gofmt -l .                                  clean
go test ./clients/... ./serve/web/...       ok
```

## After deploy

The first `/ask` on a fresh instance should log `anthropic key: read from Secret Manager`. If it logs `read from environment` or a `Secret Manager read failed` warning instead, the secret path is still broken — which is exactly the signal this PR exists to provide.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q1vR7mj67QeCDd1U5SgyHn)_