### PR TITLE
Tutor: move answer caching into a CachingAsker decorator

### DIFF
--- a/aitutor/cli.go
+++ b/aitutor/cli.go
@@ -13,10 +13,10 @@ import (
 	"github.com/opendroid/the-gpl/clients"
 )
 
-// gateway is the package-level Gateway used by the tutor command.
-// Tests can substitute gateway.Anthropic with a mock before calling
-// cmd.Execute().
-var gateway *clients.Gateway
+// tutor answers questions for the CLI, sharing the same answer cache as the web
+// tutor so a question already asked on the site costs nothing here. Tests can
+// substitute it before calling cmd.Execute().
+var tutor *clients.CachingAsker
 
 // NewTutorCmd creates the tutor command.
 func NewTutorCmd() *cobra.Command {
@@ -43,17 +43,22 @@ Examples:
 					slog.Warn("tutor: chapter README not found", "chapter", chapter, "path", path)
 				}
 			}
-			if gateway == nil || gateway.Anthropic == nil {
-				client, err := clients.NewAnthropicClient(cmd.Context())
-				if err != nil {
-					return err
-				}
-				gateway = clients.NewGateway(nil, client)
+			if tutor == nil {
+				cache, backend := clients.NewTutorCache(cmd.Context())
+				slog.Info("tutor: cache initialised", "backend", backend)
+				tutor = clients.NewCachingAsker(clients.NewLazyGateway(), cache)
 			}
-			answer, err := gateway.Ask(cmd.Context(), question, chapterCtx)
+			// Key on the chapter number only, matching the web tutor, so both
+			// share cached answers. 0 means no chapter, same as the site's "".
+			chapterKey := ""
+			if chapter > 0 {
+				chapterKey = strconv.Itoa(chapter)
+			}
+			answer, cached, err := tutor.Ask(cmd.Context(), question, chapterKey, chapterCtx)
 			if err != nil {
 				return err
 			}
+			slog.Info("tutor: answered", "cached", cached)
 			fmt.Println(answer)
 			return nil
 		},

--- a/clients/tutor.go
+++ b/clients/tutor.go
@@ -1,0 +1,85 @@
+package clients
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+)
+
+// Asker sends a Go tutor question to a model and returns its answer.
+// chapterContext is optional additional context. *Gateway satisfies Asker.
+type Asker interface {
+	Ask(ctx context.Context, question, chapterContext string) (string, error)
+}
+
+// CachingAsker wraps an Asker with an exact-match answer cache, so a repeated
+// question costs nothing. It is the single place tutor caching happens: every
+// caller that goes through it — the web handler and the tutor CLI alike — shares
+// one cache and one policy, instead of each reimplementing hit/miss handling.
+//
+// Cache failures are never fatal: a failed Get is treated as a miss and a failed
+// Put is logged, so the tutor keeps answering when the cache is unavailable.
+type CachingAsker struct {
+	inner Asker
+	cache TutorCache
+}
+
+// NewCachingAsker returns an Asker that serves exact-match repeats from cache.
+func NewCachingAsker(inner Asker, cache TutorCache) *CachingAsker {
+	return &CachingAsker{inner: inner, cache: cache}
+}
+
+// Ask returns the answer to question and whether it came from the cache.
+//
+// chapter is the chapter identifier ("8", or "" for none) and scopes the cache
+// key; chapterContext is the prose handed to the model. They are separate
+// because the key must stay stable while the context wording is free to change.
+func (c *CachingAsker) Ask(ctx context.Context, question, chapter, chapterContext string) (string, bool, error) {
+	key := TutorCacheKey(question, chapter)
+	if answer, found, err := c.cache.Get(ctx, key); err != nil {
+		slog.Error("tutor cache: get failed, treating as a miss", "err", err)
+	} else if found {
+		slog.Info("tutor cache: hit", "chapter", chapter)
+		return answer, true, nil
+	}
+
+	answer, err := c.inner.Ask(ctx, question, chapterContext)
+	if err != nil {
+		return "", false, err
+	}
+	if err := c.cache.Put(ctx, key, question, chapter, answer); err != nil {
+		slog.Error("tutor cache: put failed, answer not cached", "err", err)
+	}
+	return answer, false, nil
+}
+
+// LazyGateway is an Asker that builds its Anthropic-backed Gateway on first use.
+// Deferring construction matters for two reasons: a cache hit needs no model
+// client at all, so an unavailable API key must not block cached answers; and
+// the client is expensive enough to be worth creating once per process.
+//
+// Safe for concurrent use, unlike the package-level gateway variables it
+// replaces, which were assigned straight from HTTP handlers.
+type LazyGateway struct {
+	mu sync.Mutex
+	gw *Gateway
+}
+
+// NewLazyGateway returns an Asker that creates its Gateway on first Ask.
+func NewLazyGateway() *LazyGateway { return &LazyGateway{} }
+
+// Ask creates the Gateway if needed, then forwards the question to it.
+func (l *LazyGateway) Ask(ctx context.Context, question, chapterContext string) (string, error) {
+	l.mu.Lock()
+	if l.gw == nil || l.gw.Anthropic == nil {
+		client, err := NewAnthropicClient(ctx)
+		if err != nil {
+			l.mu.Unlock()
+			return "", err
+		}
+		l.gw = NewGateway(nil, client)
+	}
+	gw := l.gw
+	l.mu.Unlock()
+	return gw.Ask(ctx, question, chapterContext)
+}

--- a/clients/tutor_test.go
+++ b/clients/tutor_test.go
@@ -1,0 +1,117 @@
+package clients_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/opendroid/the-gpl/clients"
+)
+
+// stubAsker records how often the model was asked and what context it received.
+type stubAsker struct {
+	answer     string
+	err        error
+	calls      int
+	lastCtxArg string
+}
+
+func (s *stubAsker) Ask(_ context.Context, _, chapterContext string) (string, error) {
+	s.calls++
+	s.lastCtxArg = chapterContext
+	return s.answer, s.err
+}
+
+// brokenCache fails whichever operations it is configured to fail.
+type brokenCache struct {
+	getErr, putErr error
+	puts           int
+}
+
+func (b *brokenCache) Get(context.Context, string) (string, bool, error) {
+	return "", false, b.getErr
+}
+
+func (b *brokenCache) Put(context.Context, string, string, string, string) error {
+	b.puts++
+	return b.putErr
+}
+
+// TestCachingAsker_MissThenHit verifies the model is asked once and the second
+// identical question is served from the cache.
+func TestCachingAsker_MissThenHit(t *testing.T) {
+	ctx := context.Background()
+	inner := &stubAsker{answer: "A goroutine is a lightweight thread."}
+	a := clients.NewCachingAsker(inner, clients.NewMemoryTutorCache())
+
+	answer, cached, err := a.Ask(ctx, "What is a goroutine?", "1", "Chapter 1 — Tutorial")
+	assert.NoError(t, err)
+	assert.False(t, cached)
+	assert.Equal(t, "A goroutine is a lightweight thread.", answer)
+	assert.Equal(t, 1, inner.calls)
+	assert.Equal(t, "Chapter 1 — Tutorial", inner.lastCtxArg)
+
+	// Same question and chapter, formatted differently: still a hit.
+	answer, cached, err = a.Ask(ctx, "  what IS a   goroutine?  ", "1", "Chapter 1 — Tutorial")
+	assert.NoError(t, err)
+	assert.True(t, cached)
+	assert.Equal(t, "A goroutine is a lightweight thread.", answer)
+	assert.Equal(t, 1, inner.calls, "cache hit must not call the model")
+}
+
+// TestCachingAsker_ChapterScopesTheKey verifies the same question under a
+// different chapter is a separate entry.
+func TestCachingAsker_ChapterScopesTheKey(t *testing.T) {
+	ctx := context.Background()
+	inner := &stubAsker{answer: "answer"}
+	a := clients.NewCachingAsker(inner, clients.NewMemoryTutorCache())
+
+	_, _, err := a.Ask(ctx, "What is a channel?", "8", "ctx-8")
+	assert.NoError(t, err)
+	_, cached, err := a.Ask(ctx, "What is a channel?", "9", "ctx-9")
+	assert.NoError(t, err)
+	assert.False(t, cached)
+	assert.Equal(t, 2, inner.calls)
+}
+
+// TestCachingAsker_GetErrorIsAMiss verifies a broken cache read degrades to a
+// model call rather than an error.
+func TestCachingAsker_GetErrorIsAMiss(t *testing.T) {
+	inner := &stubAsker{answer: "answer"}
+	cache := &brokenCache{getErr: errors.New("firestore unavailable")}
+	a := clients.NewCachingAsker(inner, cache)
+
+	answer, cached, err := a.Ask(context.Background(), "q", "1", "ctx")
+	assert.NoError(t, err)
+	assert.False(t, cached)
+	assert.Equal(t, "answer", answer)
+	assert.Equal(t, 1, inner.calls)
+}
+
+// TestCachingAsker_PutErrorStillAnswers verifies a failed store is logged but
+// does not fail the request.
+func TestCachingAsker_PutErrorStillAnswers(t *testing.T) {
+	inner := &stubAsker{answer: "answer"}
+	cache := &brokenCache{putErr: errors.New("permission denied")}
+	a := clients.NewCachingAsker(inner, cache)
+
+	answer, cached, err := a.Ask(context.Background(), "q", "1", "ctx")
+	assert.NoError(t, err)
+	assert.False(t, cached)
+	assert.Equal(t, "answer", answer)
+	assert.Equal(t, 1, cache.puts)
+}
+
+// TestCachingAsker_ModelErrorIsNotCached verifies a model failure propagates and
+// nothing is stored.
+func TestCachingAsker_ModelErrorIsNotCached(t *testing.T) {
+	inner := &stubAsker{err: errors.New("api down")}
+	cache := &brokenCache{}
+	a := clients.NewCachingAsker(inner, cache)
+
+	_, _, err := a.Ask(context.Background(), "q", "1", "ctx")
+	assert.Error(t, err)
+	assert.Equal(t, 0, cache.puts, "a failed answer must not be cached")
+}

--- a/serve/web/ask_test.go
+++ b/serve/web/ask_test.go
@@ -12,13 +12,13 @@ import (
 	clientsMock "github.com/opendroid/the-gpl/mocks/clients"
 )
 
-// withTutorState swaps the package-level gateway + tutorCache for a test and
-// restores them on cleanup.
+// withTutorState swaps the package-level tutor for one backed by gw and cache,
+// and restores it on cleanup.
 func withTutorState(t *testing.T, gw *clients.Gateway, cache clients.TutorCache) {
 	t.Helper()
-	origGw, origCache := gateway, tutorCache
-	gateway, tutorCache = gw, cache
-	t.Cleanup(func() { gateway, tutorCache = origGw, origCache })
+	orig := tutor
+	tutor = clients.NewCachingAsker(gw, cache)
+	t.Cleanup(func() { tutor = orig })
 }
 
 // askResp is the decoded /ask body used in tests.
@@ -83,7 +83,7 @@ func Test_askHandler_missStores(t *testing.T) {
 
 // Test_askHandler_missingQuery: no q → 400 with an error body.
 func Test_askHandler_missingQuery(t *testing.T) {
-	withTutorState(t, gateway, clients.NewMemoryTutorCache())
+	withTutorState(t, clients.NewGateway(nil, nil), clients.NewMemoryTutorCache())
 	rr := serve(t, askHandler, "/ask")
 	assert.Equal(t, 400, rr.Code)
 

--- a/serve/web/web.go
+++ b/serve/web/web.go
@@ -25,14 +25,29 @@ import (
 var mutex sync.Mutex
 var counter int
 
-// gateway is the package-level Gateway used by askHandler. Tests can
-// substitute gateway.Anthropic with a mock.
-var gateway *clients.Gateway
+// tutor answers /ask questions, serving exact-match repeats from a cache. It is
+// built on first use and guarded by tutorMu, since handlers run concurrently.
+// Tests substitute it directly.
+var (
+	tutorMu sync.Mutex
+	tutor   *clients.CachingAsker
+)
 
-// tutorCache is the package-level answer cache used by askHandler. It is lazily
-// created on first use (Firestore in prod, in-memory otherwise). Tests can
-// substitute an in-memory cache.
-var tutorCache clients.TutorCache
+// tutorAsker returns the shared tutor, creating it on first call. The cache is
+// Firestore-backed when GOOGLE_CLOUD_PROJECT is set and in-memory otherwise, and
+// is given context.Background so its client outlives the request that built it.
+// The model client behind LazyGateway is deferred further still, so cache hits
+// are served even when no API key is available.
+func tutorAsker() *clients.CachingAsker {
+	tutorMu.Lock()
+	defer tutorMu.Unlock()
+	if tutor == nil {
+		cache, backend := clients.NewTutorCache(context.Background())
+		slog.Info("askHandler: tutor cache initialised", "backend", backend)
+		tutor = clients.NewCachingAsker(clients.NewLazyGateway(), cache)
+	}
+	return tutor
+}
 
 // handlers stores URLS to HandlerFunc
 var handlers = map[string]func(http.ResponseWriter, *http.Request){
@@ -162,46 +177,12 @@ func askHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	chapter := r.URL.Query().Get("chapter")
 
-	// Lazily create the cache: Firestore when GOOGLE_CLOUD_PROJECT is set,
-	// in-memory otherwise. context.Background so the client outlives the request.
-	if tutorCache == nil {
-		c, backend := clients.NewTutorCache(context.Background())
-		tutorCache = c
-		slog.Info("askHandler: tutor cache initialised", "backend", backend)
-	}
-
-	// Exact-match cache hit → serve without calling the model.
-	key := clients.TutorCacheKey(q, chapter)
-	if answer, found, err := tutorCache.Get(r.Context(), key); err != nil {
-		slog.Error("askHandler: cache get", "err", err) // treat as a miss
-	} else if found {
-		slog.Info("askHandler: cache hit", "chapter", chapter)
-		_ = json.NewEncoder(w).Encode(askResponse{Answer: answer, Cached: true})
-		return
-	}
-
-	// Miss → ensure a gateway, then ask the model with chapter context.
-	if gateway == nil || gateway.Anthropic == nil {
-		client, err := clients.NewAnthropicClient(r.Context())
-		if err != nil {
-			slog.Error("askHandler: tutor client init error", "err", err)
-			w.WriteHeader(http.StatusInternalServerError)
-			_ = json.NewEncoder(w).Encode(askResponse{Error: err.Error()})
-			return
-		}
-		gateway = clients.NewGateway(nil, client)
-	}
-	answer, err := gateway.Ask(r.Context(), q, chapterContext(chapter))
+	answer, cached, err := tutorAsker().Ask(r.Context(), q, chapter, chapterContext(chapter))
 	if err != nil {
 		slog.Error("askHandler: tutor error", "err", err)
 		w.WriteHeader(http.StatusInternalServerError)
 		_ = json.NewEncoder(w).Encode(askResponse{Error: err.Error()})
 		return
 	}
-
-	// Best-effort store; a cache failure must not fail the response.
-	if err := tutorCache.Put(r.Context(), key, q, chapter, answer); err != nil {
-		slog.Error("askHandler: cache put", "err", err)
-	}
-	_ = json.NewEncoder(w).Encode(askResponse{Answer: answer, Cached: false})
+	_ = json.NewEncoder(w).Encode(askResponse{Answer: answer, Cached: cached})
 }


### PR DESCRIPTION
Closes #73.

Caching lived inside `askHandler`, making it a property of one caller rather than of the tutor operation. `aitutor/cli.go` called `gateway.Ask` directly, so `the-gpl tutor` paid full API cost on every repeat — including questions the website had already answered and cached.

## Approach

A decorator in `clients`, not a merge into `Gateway`. `Gateway` is already an aggregate of two unrelated API clients; folding the cache in would make it the place every concern accretes, and would force its `Ask` signature to carry a cache-hit flag that its Dialogflow half has no use for.

```go
type Asker interface {
    Ask(ctx context.Context, question, chapterContext string) (string, error)
}

type CachingAsker struct { inner Asker; cache TutorCache }
func (c *CachingAsker) Ask(ctx, question, chapter, chapterContext string) (string, bool, error)
```

`*Gateway` already satisfies `Asker`, so **`Gateway` is not modified at all** — the composition falls out of Go's implicit interface satisfaction.

Keeping `chapter` (the id, which scopes the cache key) separate from `chapterContext` (the prose sent to the model) is what makes this work: the key stays stable while context wording is free to change. Folding into `Gateway.Ask`, which only receives the rendered prose, would have meant keying on the description text — so editing one word of a chapter blurb would silently invalidate that chapter's cache.

## What changed

- **`clients/tutor.go`** (new): `Asker`, `CachingAsker`, and `LazyGateway`.
- **`serve/web/web.go`**: `askHandler` drops from ~45 lines to ~11 — parse, ask, encode. The `gateway` and `tutorCache` globals collapse into one `tutor`, built behind a mutex.
- **`aitutor/cli.go`**: goes through the same decorator, so the CLI now shares the website's cache. Chapter 0 maps to `""` so both callers produce identical keys for "no chapter".

`LazyGateway` defers creating the model client until a miss actually needs one. That is not incidental — the old ordering checked the cache *before* building the client, so cache hits worked without an API key, and a naive refactor would have regressed it.

## Incidental fix

`gateway` and `tutorCache` were assigned straight from the handler with no synchronisation, so two concurrent first requests raced on both writes. Construction is now behind `tutorMu`, and `LazyGateway` has its own mutex. No test exercised that path, so `-race` never flagged it.

## Tests

Five new tests for `CachingAsker` covering miss→hit (including that a hit does not call the model, and that whitespace/case differences still hit), chapter scoping the key, `Get` errors degrading to a miss, `Put` errors still answering, and a model error propagating without being cached. The existing `/ask` tests keep working against the new shape via an updated `withTutorState`.

```
go build ./...                                    clean
go vet ./...                                      clean
gofmt -l .                                        clean
go test ./clients/... ./serve/web/... -race       ok
```

## Behavior verification

Ran the server and exercised `/ask` directly: no-key error is byte-identical (`{"error":"ANTHROPIC_API_KEY not set and Secret Manager unavailable","cached":false}`), missing `q` still returns 400, and the `askHandler: tutor cache initialised backend=memory` line still appears — that log is what today's production debugging relies on, so it deliberately did not move.

## Note on shared keys

The two callers supply different chapter context for the same key: the site sends a one-line description, the CLI sends the full chapter README. Sharing is intentional — both are chapter-scoped answers to the same question — but it does mean a cached answer may have been produced with the other caller's context. If that ever matters, mixing a context fingerprint into the key would separate them, at the cost of the sharing this PR exists to enable.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q1vR7mj67QeCDd1U5SgyHn)_