### PR TITLE
docs: document the AI tutor and its answer cache in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ Live at **https://the-gpl.com** (GCP Cloud Run).
 ## Module
 
 ```
-github.com/opendroid/the-gpl   (Go 1.25)
+github.com/opendroid/the-gpl   (Go 1.26)
 ```
 
 ## Repository Layout
@@ -22,9 +22,13 @@ chapter5/          Functions — HTML traversal, web crawler, topological sort, 
 chapter6/          Methods — IntSet bit-vector type, pointer vs value receivers
 chapter7/          Interfaces — temperature converter, http.Handler counter, sort.Interface, CLI
 chapter8/          Goroutines & channels — clock/reverb/chat TCP services, concurrent du, web search
+chapter9/          Concurrency & shared variables — sync.Mutex/RWMutex banks, sync.Once, Memo cache
+aitutor/           `tutor` CLI command for the Claude-powered Go tutor
 cmd/               Cobra CLI root command and shared plumbing
-serve/web/         HTTP handlers, HTML templates (webtpl.go), static file serving
-clients/           HTTP client utilities
+serve/web/         HTTP handlers, HTML templates (webtpl.go), static file serving,
+│                  tutor page data (tutordata.go)
+clients/           External API clients — Anthropic, Dialogflow, the Gateway that
+│                  aggregates them, and the tutor answer cache (tutorcache.go, tutor.go)
 mocks/             golang/mock generated mocks
 public/            Static assets served at /public/css/ and /public/images/
 ```
@@ -55,20 +59,75 @@ the-gpl server --port=8080   # start web server
 | `service` / `client` | `chapter8` | TCP clock / reverb / chat |
 | `bot` | `chapter1/bot` | Dialogflow conversational agent |
 | `stt` | `chapter1/livecaption` | Google Speech-to-Text from RTP stream |
+| `tutor` | `aitutor` | Ask the Claude-powered Go tutor (`--q`, `--chapter`) |
 
 ## Architecture
 
 - **Single binary**: `main.go` wires cobra commands from all chapters + the web server.
 - **Web server** (`serve/web/`): `Start()` in `web.go` registers all `http.HandleFunc` entries defined in `handlers` map; templates are in `webtpl.go`; page-data types in `pagedata.go`; home/demos static data in `demodata.go`.
 - **Theme**: `public/css/redesign/` is the only theme (light, JetBrains Mono + Helvetica), linked from `head.gohtml`. The previous dark theme (`public/css/initial/`) was removed; recover it from git history if ever needed.
-- **Cloud Run**: deployed as a single container (`Dockerfile`, `cloudbuild.yaml`) with one instance — no shared state concerns between replicas.
+- **Cloud Run**: deployed as a single container (`Dockerfile`, `cloudbuild.yaml`) with one instance — no shared state concerns between replicas. The one piece of state that does outlive a container is the tutor answer cache in Firestore (see below).
 - **External APIs**: Dialogflow and Speech-to-Text require `GOOGLE_APPLICATION_CREDENTIALS` to point to a GCP service-account JSON file. Never commit credentials.
+
+## AI Tutor
+
+The tutor answers Go questions via Claude, at `/ask-page` (UI, which calls `/ask`) and
+`the-gpl tutor` (CLI). Both callers share one cache and one caching implementation, so
+a question answered on the site is free from the CLI and vice versa.
+
+```
+askHandler (serve/web/web.go)  ─┐
+                                ├─► clients.CachingAsker ─► clients.TutorCache
+tutor CLI (aitutor/cli.go)     ─┘         │                  (Firestore | memory)
+                                          └─► clients.LazyGateway ─► Gateway.Ask ─► Claude
+```
+
+- **`clients.CachingAsker`** (`clients/tutor.go`) is the only place caching happens.
+  It wraps any `Asker` — an interface `*Gateway` already satisfies, so `Gateway`
+  itself knows nothing about caching. `Ask` returns `(answer, cached, error)`.
+- **Cache key** is `sha256(chapter + "\n" + normalized question)`, where the question
+  is lower-cased with whitespace collapsed. The **chapter id** ("8", or "" for none)
+  scopes the key; the **chapter context** prose sent to the model is deliberately
+  *not* in the key, so reworded descriptions do not invalidate entries. Matching is
+  exact by design — near-duplicate questions miss.
+- **`clients.LazyGateway`** defers creating the Anthropic client until a cache miss
+  actually needs it, so cache hits are served even when the API key is unavailable.
+  Do not hoist client creation above the cache lookup.
+- **Backends** (`clients/tutorcache.go`): Firestore (collection `tutor_cache`) when
+  `GOOGLE_CLOUD_PROJECT` is set and reachable, otherwise an in-memory map that lives
+  only as long as the process. `NewTutorCache` **probes** the database before
+  reporting `firestore`, because `firestore.NewClient` never contacts the server and
+  would otherwise report success against a project with no database at all.
+- **Cache failures are never fatal**: a failed `Get` is treated as a miss, a failed
+  `Put` is logged and the answer still returned.
+- **Chapter data** (`serve/web/tutordata.go`): `bookChapters` is the single source of
+  truth for the nine chapters, used by both `/chapters` and the tutor's chapter
+  context. `chapterPrompts` drives the suggestion chips, marshalled into the page as
+  `AskPageData.PromptsJSON`.
+
+### Diagnosing the tutor from logs
+
+Both external dependencies report which source they resolved to, so a misconfiguration
+is visible while the site still works rather than only when a fallback is removed:
+
+| Log message | Meaning |
+|---|---|
+| `askHandler: tutor cache initialised` + `backend=firestore` | Probed and writable — answers persist |
+| ...same with `backend=memory` | No/unreachable Firestore; cache is per-process only |
+| `tutor cache: hit` | Served without a model call |
+| `anthropic key: read from Secret Manager` | Key came from `ANTHROPIC_API_KEY` secret |
+| `anthropic key: read from environment` | Secret Manager unavailable; env fallback in use |
+
+Firestore needs `roles/datastore.user` and Secret Manager `roles/secretmanager.secretAccessor`
+on the Cloud Run runtime service account.
 
 ## Environment Variables
 
 | Variable | Required for |
 |---|---|
 | `GOOGLE_APPLICATION_CREDENTIALS` | Dialogflow bot, Speech-to-Text |
+| `ANTHROPIC_API_KEY` | AI tutor — local dev, and the fallback if Secret Manager is unavailable |
+| `GOOGLE_CLOUD_PROJECT` | AI tutor — when set, the key is read from Secret Manager and the answer cache uses Firestore. Set automatically on Cloud Run |
 
 ## Coding Conventions
 
@@ -83,3 +142,8 @@ the-gpl server --port=8080   # start web server
 - `GOOGLE_APPLICATION_CREDENTIALS` handling — credentials must stay out of source.
 - The cobra command wiring in `main.go` — add new commands there following the existing pattern.
 - `public/` static assets — images are referenced by the HTML templates; paths are hardcoded.
+- The tutor cache-key inputs (`TutorCacheKey`) — changing normalization or what the key
+  covers invalidates every cached answer in Firestore.
+- The `Asker` seam between `CachingAsker` and `Gateway` — folding the cache into
+  `Gateway` was considered and rejected; it would key on chapter prose instead of the
+  chapter id and force a cache-hit flag onto the Dialogflow side of `Gateway`.


### PR DESCRIPTION
CLAUDE.md still described the repository as it was before the tutor gained a cache — no mention of the caching layer, the Firestore/memory backends, the tutor CLI, or the two environment variables the tutor depends on.

## New: AI Tutor section

A diagram of the path both callers share, then the parts that are load-bearing and easy to break:

- **`CachingAsker` is the only place caching happens**, wrapping an `Asker` that `*Gateway` already satisfies — so `Gateway` stays unaware of caching.
- **What the cache key covers**: the chapter *id* scopes it, the chapter *context prose* deliberately does not, so reworded descriptions don't invalidate entries.
- **Why `LazyGateway` exists**: hoisting client creation above the cache lookup would stop cache hits working without an API key.
- **Why `NewTutorCache` probes**: `firestore.NewClient` never contacts the server, so without the probe it reports success against a project with no database.
- **Cache failures are never fatal** — failed `Get` is a miss, failed `Put` is logged.

Plus a **log-message table** for diagnosing which cache backend and which key source a deployment actually resolved to. Both dependencies fall back silently by design, so the log line is the only way to tell a working Firestore from a broken one — which cost real debugging time today.

Two entries added to **Do NOT Change**: the cache-key inputs (changing them invalidates every stored answer), and the `Asker` seam, with a one-line note that folding the cache into `Gateway` was considered and rejected.

## Adjacent staleness fixed

Corrections the new section would otherwise contradict, all verified against the tree:

| Was | Now |
|---|---|
| `Go 1.25` | `Go 1.26` (matches `go.mod`) |
| layout missing `chapter9/`, `aitutor/` | both listed |
| `clients/` — "HTTP client utilities" | external API clients, Gateway, tutor cache |
| no `tutor` command in the table | listed with its flags |
| env table: only `GOOGLE_APPLICATION_CREDENTIALS` | plus `ANTHROPIC_API_KEY`, `GOOGLE_CLOUD_PROJECT` |

The Cloud Run bullet claiming "no shared state concerns" now notes the Firestore cache as the one piece of state outliving a container.

Docs-only — no code touched. `go build ./...` and the package tests still pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q1vR7mj67QeCDd1U5SgyHn)_