### PR TITLE
docs: warn that GOOGLE_APPLICATION_CREDENTIALS also selects the tutor's credentials

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,6 +105,32 @@ tutor CLI (aitutor/cli.go)     ─┘         │                  (Firestore | 
   context. `chapterPrompts` drives the suggestion chips, marshalled into the page as
   `AskPageData.PromptsJSON`.
 
+### Local development: the ADC gotcha
+
+`GOOGLE_APPLICATION_CREDENTIALS` is exported locally so the Dialogflow bot and
+Speech-to-Text work, but it also selects the Application Default Credentials used
+by *every* Google client in the process — including the tutor's Firestore and
+Secret Manager clients. If that service account lacks `roles/datastore.user` and
+`roles/secretmanager.secretAccessor` (the Dialogflow/STT account has no reason to
+hold either), the tutor quietly degrades to the in-process cache and the
+`ANTHROPIC_API_KEY` environment variable. Answers stay correct, so the only
+symptom is that every local run misses the cache and pays for an API call.
+
+The signature is two WARN lines at startup:
+
+```
+"tutor cache: firestore unreachable, falling back to memory"  err=...PermissionDenied
+"anthropic key: Secret Manager read failed, trying environment"  err=...denied
+```
+
+Either grant that service account the two roles, or bypass the key file so ADC
+falls back to user credentials:
+
+```bash
+env -u GOOGLE_APPLICATION_CREDENTIALS GOOGLE_CLOUD_PROJECT=the-gpl \
+  go run . tutor --chapter 4 --q "What is a nil map?"
+```
+
 ### Diagnosing the tutor from logs
 
 Both external dependencies report which source they resolved to, so a misconfiguration

--- a/README.md
+++ b/README.md
@@ -57,6 +57,42 @@ $ the-gpl tutor --q="What is a goroutine?"
 $ the-gpl tutor --chapter=5 --q="How does HTML traversal work?"
 ```
 
+#### Answer cache
+Identical questions (same text, ignoring case and extra whitespace, plus the same chapter) are served
+from an answer cache instead of calling the paid API. The CLI and the website share one cache, so a
+question already answered on https://the-gpl.com is free from the CLI and vice versa. When
+`GOOGLE_CLOUD_PROJECT` is set and Firestore is reachable, answers persist in the `tutor_cache`
+collection; otherwise the cache lives only as long as the process. The active backend is logged at
+startup as `tutor: cache initialised backend=firestore|memory`.
+
+#### Gotcha: `GOOGLE_APPLICATION_CREDENTIALS` also decides the tutor's credentials
+The variable you set above for Dialogflow and Speech-to-Text selects the Application Default
+Credentials for *every* Google client in the process — including the tutor's Firestore and Secret
+Manager clients. If that service account lacks `roles/datastore.user` and
+`roles/secretmanager.secretAccessor`, the tutor still answers correctly but silently falls back to the
+in-process cache and the `ANTHROPIC_API_KEY` variable, so every run misses the shared cache and pays
+for a fresh API call. Two WARN lines at startup give it away:
+
+```
+"tutor cache: firestore unreachable, falling back to memory"   err=...PermissionDenied
+"anthropic key: Secret Manager read failed, trying environment" err=...denied
+```
+
+Either grant that service account the two roles:
+```shell script
+$ SA='serviceAccount:your-sa@your-project.iam.gserviceaccount.com'
+$ gcloud projects add-iam-policy-binding your-project --member="$SA" --role='roles/datastore.user'
+$ gcloud secrets add-iam-policy-binding ANTHROPIC_API_KEY --member="$SA" \
+    --role='roles/secretmanager.secretAccessor' --project=your-project
+```
+
+...or bypass the key file for the tutor so ADC falls back to your user credentials
+(`gcloud auth application-default login` first):
+```shell script
+$ env -u GOOGLE_APPLICATION_CREDENTIALS GOOGLE_CLOUD_PROJECT=your-project \
+    the-gpl tutor --chapter=4 --q="What is the zero value of a nil map in Go?"
+```
+
 ### Simple Examples from book
 Use these commands to run utilities:
 1. bits: That counts number of 1 bits in a Hex input 


### PR DESCRIPTION
Closes #76.

The README tells you to export `GOOGLE_APPLICATION_CREDENTIALS` for Dialogflow and Speech-to-Text. That same variable selects Application Default Credentials for *every* Google client in the process — including the Firestore and Secret Manager clients the tutor added. A Dialogflow/STT service account has no reason to hold `roles/datastore.user` or `roles/secretmanager.secretAccessor`, so the tutor falls back to the in-process cache and the environment key.

Answers stay correct, which is exactly what makes it easy to miss: the only symptom is that every local run misses the shared cache and pays for an API call. Hit this while verifying the shared cache — the CLI took ~6s with `backend=memory` where it should have taken ~150ms with `backend=firestore`.

## README.md

Two subsections under **AI Tutor (Claude)**:

- **Answer cache** — the README had never mentioned it. Covers what counts as an identical question, that the CLI and website share one cache, and the `backend=firestore|memory` startup line.
- **Gotcha** — the credential interaction, the two WARN lines that identify it, and both remedies as copy-pasteable commands (grant the service account the two roles, or `env -u GOOGLE_APPLICATION_CREDENTIALS` so ADC falls back to user credentials).

## CLAUDE.md

A **Local development: the ADC gotcha** subsection in the AI Tutor section, ahead of the existing log-diagnosis table, with the same signature and remedies.

## Why docs and not code

The fallbacks are deliberate — an unreachable Firestore or Secret Manager must not break `/ask` — and since #69 and #71 they announce themselves with the failing permission named. Nothing is silent any more at the log level. What was missing is any hint that a variable the README instructs you to set for one feature changes the behavior of another.

Docs-only, no code touched. `go build ./...` and the package tests still pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q1vR7mj67QeCDd1U5SgyHn)_